### PR TITLE
SD: change URLs to use www.sdlegislature.gov

### DIFF
--- a/openstates/sd/__init__.py
+++ b/openstates/sd/__init__.py
@@ -13,7 +13,7 @@ metadata = dict(
     name = 'South Dakota',
     abbreviation = 'sd',
     legislature_name = 'South Dakota State Legislature',
-    legislature_url = 'http://legis.state.sd.us/',
+    legislature_url = 'http://www.sdlegislature.gov/',
     capitol_timezone = 'America/Chicago',
     chambers = {
         'upper': {'name': 'Senate', 'title': 'Senator'},
@@ -93,11 +93,12 @@ metadata = dict(
 
 
 def session_list():
-    html = scrapelib.Scraper().get('http://legis.sd.gov/Legislative_Session/'
-        'Menu.aspx').text
+    html = scrapelib.Scraper().get('http://www.sdlegislature.gov/'
+                                   'Legislative_Session/Menu.aspx').text
     doc = lxml.html.fromstring(html)
-    sessions = doc.xpath('//div[@id="ContentPlaceHolder1_BlueBoxLeft"]//ul/li'
-        '/a/div/text()')
+    sessions = doc.xpath('//div[contains(@id, '
+                         '"ContentPlaceHolder1_BlueBoxLeft")]'
+                         '//ul/li/a/div/text()')
     return sessions
 
 

--- a/openstates/sd/bills.py
+++ b/openstates/sd/bills.py
@@ -10,7 +10,8 @@ class SDBillScraper(BillScraper):
     jurisdiction = 'sd'
 
     def scrape(self, chamber, session):
-        url = 'http://legis.sd.gov/Legislative_Session/Bills/default.aspx?Session=%s' % session
+        url = 'http://www.sdlegislature.gov/Legislative_Session' \
+              '/Bills/default.aspx?Session={}'.format(session)
 
         if chamber == 'upper':
             bill_abbr = 'S'

--- a/openstates/sd/legislators.py
+++ b/openstates/sd/legislators.py
@@ -10,7 +10,8 @@ class SDLegislatorScraper(LegislatorScraper):
 
     def scrape(self, chamber, term):
         year = term[0:4]
-        url = 'http://legis.sd.gov/Legislators/default.aspx?CurrentSession=True'
+        url = 'http://www.sdlegislature.gov/Legislators/default.aspx' \
+              '?CurrentSession=True'
 
         if chamber == 'upper':
             search = 'Senate Members'
@@ -21,11 +22,12 @@ class SDLegislatorScraper(LegislatorScraper):
         page = lxml.html.fromstring(page)
         page.make_links_absolute(url)
 
-        for link in page.xpath("//h4[text()='%s']/../div/a" % search):
+        for link in page.xpath("//h4[text()='{}']/../div/a".format(search)):
             name = link.text.strip()
 
             self.scrape_legislator(name, chamber, term,
-                                   link.attrib['href'])
+                                   '{}&Cleaned=True'.format(
+                                       link.attrib['href']))
 
     def scrape_legislator(self, name, chamber, term, url):
         page = self.get(url).text
@@ -45,7 +47,7 @@ class SDLegislatorScraper(LegislatorScraper):
             "string(//span[contains(@id, 'Occupation')])")
         occupation = occupation.strip()
 
-        (photo_url, ) = page.xpath('//img[@id="ContentPlaceHolder1_imgMember"]/@src')
+        (photo_url, ) = page.xpath('//img[contains(@id, "_imgMember")]/@src')
 
         office_phone = page.xpath(
             "string(//span[contains(@id, 'CapitolPhone')])").strip()
@@ -92,7 +94,8 @@ class SDLegislatorScraper(LegislatorScraper):
         for link in page.xpath("//a[contains(@href, 'CommitteeMem')]"):
             comm = link.text.strip()
 
-            role = link.xpath('../following-sibling::td')[0].text_content().lower()
+            role = link.xpath('../following-sibling::td')[0]\
+                .text_content().lower()
 
             if comm.startswith('Joint'):
                 chamber = 'joint'


### PR DESCRIPTION
Requests to `legis.sd.gov` are re-directing to `www.sdlegislature.gov` and scraping will not complete. This is to change the URLs to the new one. Also, some div IDs have changed on the site, and scraping was not working because of those. I have corrected those as well.
