### PR TITLE
Issue 1172 - handle name parsing when BOM messes w/ XML tree

### DIFF
--- a/openstates/tn/legislators.py
+++ b/openstates/tn/legislators.py
@@ -76,7 +76,7 @@ class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
 
             member_page = lxml.html.fromstring(member_page)
             try:
-                name = member_page.xpath('//h1/text()')[0]
+                name = member_page.xpath('//div/div/h1/text()')[0]
             except IndexError:
                 name = member_page.xpath('//div[@id="membertitle"]/h2/text()')[0]
             

--- a/openstates/tn/legislators.py
+++ b/openstates/tn/legislators.py
@@ -76,7 +76,7 @@ class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
 
             member_page = lxml.html.fromstring(member_page)
             try:
-                name = member_page.xpath('body/div/div/h1/text()')[0]
+                name = member_page.xpath('//h1/text()')[0]
             except IndexError:
                 name = member_page.xpath('//div[@id="membertitle"]/h2/text()')[0]
             


### PR DESCRIPTION
As stated in the issue, it looks like lxml parses the DOM tree differently when [BOM](http://unicode.org/faq/utf_bom.html) are at the start of a stream of HTML text.  Running the scrape, it looks like only the pages for Senate District 19 and District 4 are affected in the 109th GA.

The "h1" element holding the name is still present for the District 19 page.  District 4 uses the fallback handler, which was still working despite the BOM.  To handle the normal case for "h1" names, and this BOM case, the diff replaces "body/div/div/h1..." with "//h1".  This still scraped names correctly for the remaining 109th GA senators and house members.

Closes  #1172