### PR TITLE
Workaround for OK website bug with 2017 session display

### DIFF
--- a/openstates/ok/__init__.py
+++ b/openstates/ok/__init__.py
@@ -67,7 +67,7 @@ metadata = dict(
          '2017-2018':
             {'display_name': '2017-2018 Regular Session',
              'session_id': '1700',
-             '_scraped_name': '2017 Regular Session',
+             '_scraped_name': '2017 Regular Session(mainsys)',
             },            
         },
     feature_flags=['subjects', 'influenceexplorer'],


### PR DESCRIPTION
OK added some junk to the 2017 session in their dropdown, so until they fix it, change the scraped name.