### PR TITLE
MO: Update for 2017 session

### DIFF
--- a/openstates/mo/bills.py
+++ b/openstates/mo/bills.py
@@ -412,10 +412,6 @@ class MOBillScraper(BillScraper, LXMLMixin):
             bill_sponsor_link = table_rows[0][1][0].attrib['href']
         except IndexError:
             return
-
-        if bill_sponsor_link:
-            bill_sponsor_link = '%s%s' % (self._senate_base_url,bill_sponsor_link)
-
         bill.add_sponsor('primary', bill_sponsor, sponsor_link=bill_sponsor_link)
 
         # check for cosponsors


### PR DESCRIPTION
Absolute minimum code to get MO working for 2017 session. Senate membership (and comms) hasn't been updated yet, but all bills and house members and comms are looking good, including data quality check.

Inferior to https://github.com/openstates/openstates/pull/1075, but quicker to integrate.