### PR TITLE
[WIP] IN: Add 2017 session and temporarily stop version scraping

### DIFF
--- a/openstates/in/__init__.py
+++ b/openstates/in/__init__.py
@@ -26,6 +26,8 @@ metadata = dict(
          'end_year': 2014, 'sessions': ['2013', '2014']},
         {'name': '2015-2016', 'start_year': 2015,
          'end_year': 2016, 'sessions': ['2015', '2016']},
+        {'name': '2017-2017', 'start_year': 2017,
+         'end_year': 2018, 'sessions': ['2017']},
         ],
     session_details={
         '2009': {'display_name': '2009 Regular Session',
@@ -45,6 +47,11 @@ metadata = dict(
             '_scraped_name': 'First Regular Session 119th General Assembly (2015)'},
         '2016': {'display_name': '2016 Regular Session',
             '_scraped_name': 'Second Regular Session 119th General Assembly (2016)'},
+       '2017': {'display_name': '2017 Regular Session',
+            '_scraped_name': 'First Regular Session 120th General Assembly (2017)',
+            'start_date': datetime.date(2017, 1, 9),
+            'end_date': datetime.date(2017, 4, 29)
+            },
         },
     feature_flags=['subjects', 'capitol_maps', 'influenceexplorer'],
     capitol_maps=[

--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -195,7 +195,7 @@ class INBillScraper(BillScraper):
 
         #votes
         votes = version["rollcalls"]
-        #self._process_votes(votes,bill,proxy)
+        self._process_votes(votes,bill,proxy)
 
     def scrape(self, session, chambers):
         self._bill_prefix_map = {

--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -130,7 +130,7 @@ class INBillScraper(BillScraper):
                 "No vote counts ({count}) don't match count of actual votes ({actual})".format(count=vote["no_count"],actual=len(vote["no_votes"]))
             assert len(vote["other_votes"]) == vote["other_count"],\
                 "Other vote counts ({count}) don't match count of actual votes ({actual})".format(count=vote["other_count"],actual=len(vote["other_votes"]))
-            
+
             #indiana only has simple majorities even for veto overrides
             #if passage status isn't the same as yes>no, then we should look!
             bill_type = bill['type'][0]
@@ -144,7 +144,7 @@ class INBillScraper(BillScraper):
             else:
                 if vote['passed'] != (vote['yes_count'] > vote['no_count']):
                     vote_invalid = True
-            
+
             if vote_invalid:
                 raise AssertionError('Vote count doesn\'t agree with vote '
                     'passage status.')
@@ -190,7 +190,7 @@ class INBillScraper(BillScraper):
                     continue
                 else:
                     break
-                
+
             bill.add_version(name,link,mimetype="application/pdf",date=update_date)
 
         #votes
@@ -250,7 +250,7 @@ class INBillScraper(BillScraper):
         }
 
         api_base_url = "https://api.iga.in.gov"
-        proxy = {"url":"http://in.proxy.openstates.org"}
+        proxy = {"url":"http://in-proxy.openstates.org"}
 
         #ah, indiana. it's really, really hard to find
         #pdfs in their web interface. Super easy with
@@ -280,7 +280,7 @@ class INBillScraper(BillScraper):
             except scrapelib.HTTPError:
                 self.logger.warning('Bill could not be accessed. Skipping.')
                 continue
-            
+
             title = bill_json["title"]
             if title == "NoneNone":
                 title = None
@@ -352,13 +352,13 @@ class INBillScraper(BillScraper):
                 else:
                     action_chamber = "upper"
                 date = a["date"]
-                
+
                 if not date:
                     self.logger.warning("Action has no date, skipping")
                     continue
 
                 date = datetime.datetime.strptime(date,"%Y-%m-%dT%H:%M:%S")
-                
+
                 action_type = []
                 d = action_desc.lower()
                 committee = None
@@ -451,7 +451,7 @@ class INBillScraper(BillScraper):
                 except scrapelib.HTTPError:
                     self.logger.warning("Bill version does not seem to exist.")
                     continue
-                
+
                 self.deal_with_version(version_json,bill,proxy)
 
             self.save_bill(bill)

--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -195,7 +195,7 @@ class INBillScraper(BillScraper):
 
         #votes
         votes = version["rollcalls"]
-        self._process_votes(votes,bill,proxy)
+        #self._process_votes(votes,bill,proxy)
 
     def scrape(self, session, chambers):
         self._bill_prefix_map = {

--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -124,12 +124,12 @@ class INBillScraper(BillScraper):
                         if v.strip():
                             vote[currently_counting].append(v.strip())
 
-            assert len(vote["yes_votes"]) == vote["yes_count"],\
-                "Yes vote counts ({count}) don't match count of actual votes ({actual})".format(count=vote["yes_count"],actual=len(vote["yes_votes"]))
-            assert len(vote["no_votes"]) == vote["no_count"],\
-                "No vote counts ({count}) don't match count of actual votes ({actual})".format(count=vote["no_count"],actual=len(vote["no_votes"]))
-            assert len(vote["other_votes"]) == vote["other_count"],\
-                "Other vote counts ({count}) don't match count of actual votes ({actual})".format(count=vote["other_count"],actual=len(vote["other_votes"]))
+            if len(vote["yes_votes"]) == vote["yes_count"]:
+                self.logger.warning("Yes vote counts ({count}) don't match count of actual votes ({actual}): {url}".format(count=vote["yes_count"],actual=len(vote["yes_votes"]), url=proxy_link))
+            if len(vote["no_votes"]) == vote["no_count"]:
+                self.logger.warning("No vote counts ({count}) don't match count of actual votes ({actual}): {url}".format(count=vote["no_count"],actual=len(vote["no_votes"]), url=proxy_link))
+            if len(vote["other_votes"]) == vote["other_count"]:
+                self.logger.warning("Other vote counts ({count}) don't match count of actual votes ({actual}): {url}".format(count=vote["other_count"],actual=len(vote["other_votes"]),url=proxy_link))
 
             #indiana only has simple majorities even for veto overrides
             #if passage status isn't the same as yes>no, then we should look!


### PR DESCRIPTION
Scraping votes/versions is causing the scraper to hang, maybe because the session is missing in the openstates api? 

This adds 2017 to the metadata and comments out the function that breaks the bill scraper.