### PR TITLE
Use `Scraper.get` in `LXMLMixin.lxmlize`

### DIFF
--- a/openstates/utils/lxmlize.py
+++ b/openstates/utils/lxmlize.py
@@ -14,11 +14,13 @@ class LXMLMixin(object):
             Element: Document node representing the page.
         """
         try:
-            response = requests.get(url)
+            # This class is always mixed into subclasses of `billy.Scraper`,
+            # which have a `get` method defined.
+            response = self.get(url)
         except requests.exceptions.SSLError:
             self.warning('`self.lxmlize()` failed due to SSL error, trying'\
-                'an unverified `requests.get()`')
-            response = requests.get(url, verify=False)
+                'an unverified `self.get()` (i.e. `requests.get()`)')
+            response = self.get(url, verify=False)
 
         if raise_exceptions:
             response.raise_for_status()


### PR DESCRIPTION
Fix #1214 

Convert the `LXMLMixin.lxmlize` method to use the `get` method defined
by the subclass of `billy.Scraper` for which `LXMLMixin` will serve as a
mixin, instead of `requests.get`. Using the scrapers `get` method uses
cached responses during `--fast` scrapes, which saves time.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>