### PR TITLE
Fix README.rst test command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,6 @@ Testing
 ====
 To run all tests::
 
-  docker run openstates/openstates --entrypoint=nosetests /srv/openstates-web/openstates
+  docker run --entrypoint=nosetests openstates/openstates /srv/openstates-web/openstates
 
 Note that Illinois (il) is the only state with tests right now.


### PR DESCRIPTION
Fix #1222 

Fix the command included in the `README.rst` for running the test suite,
as the previous command specified the command line flags in an incorrect
order.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>