### PR TITLE
MS: Add recent sessions, update legislators

### DIFF
--- a/openstates/ms/__init__.py
+++ b/openstates/ms/__init__.py
@@ -41,7 +41,8 @@ metadata = {
             'name': '2016-2019',
             'start_year': 2016, 'end_year': 2019,
             'sessions': [
-                '2016', '20161E'
+                '2016', '20161E', '20162E',
+                '2017',
             ],
         },
     ],
@@ -128,6 +129,14 @@ metadata = {
         '20161E': {
             'display_name': '2016 First Extraordinary Session',
             '_scraped_name': '2016 First Extraordinary Session'
+        },
+        '20162E': {
+            'display_name': '2016 Second Extraordinary Session',
+            '_scraped_name': '2016 Second Extraordinary Session'
+        },
+        '2017': {
+            'display_name': '2017 Regular Session',
+            '_scraped_name': '2017 Regular Session',
         },
     },
     'feature_flags': ['subjects', 'influenceexplorer'],

--- a/openstates/ms/legislators.py
+++ b/openstates/ms/legislators.py
@@ -95,10 +95,10 @@ class MSLegislatorScraper(LegislatorScraper):
             email_name = root.xpath('string(//EMAIL_ADDRESS)').strip()
             cap_room = root.xpath('string(//CAP_ROOM)')
 
-            if leg_name in ('Lataisha Jackson', 'John G. Faulkner'):
+            if leg_name in ('Lataisha Jackson', 'John G. Faulkner', 'Abe Hudson'):
                 assert not party, "Remove special-casing for this Democrat without a listed party: {}".format(leg_name)
                 party = 'Democratic'
-            elif leg_name in ('James W. Mathis', 'J. Walter Michel'):
+            elif leg_name in ('James W. Mathis', 'Donnie Scoggin', 'John Glen Corley'):
                 assert not party, "Remove special-casing for this Republican without a listed party: {}".format(leg_name)
                 party = 'Republican'
             elif party == 'D':
@@ -146,4 +146,3 @@ class MSLegislatorScraper(LegislatorScraper):
             self.save_legislator(leg)
         except scrapelib.HTTPError, e:
             self.warning(str(e))
-


### PR DESCRIPTION
A small update to the MS scraper.

The first commit adds the metadata for the 20162E and 2017 sessions.

The second commit updates the party assignments for newly elected representatives. In Mississippi, candidates in special elections run without party labels, so all the representatives elected this November needed exceptions. "J. Walter Michel" was elected in a special election in March and now has an official party affiliation.