### PR TITLE
MS: Adjust list of legislators with manual party assignments

### DIFF
--- a/openstates/ms/legislators.py
+++ b/openstates/ms/legislators.py
@@ -95,10 +95,10 @@ class MSLegislatorScraper(LegislatorScraper):
             email_name = root.xpath('string(//EMAIL_ADDRESS)').strip()
             cap_room = root.xpath('string(//CAP_ROOM)')
 
-            if leg_name in ('Lataisha Jackson', 'John G. Faulkner'):
+            if leg_name in ('Lataisha Jackson', 'John G. Faulkner', 'Abe Hudson'):
                 assert not party, "Remove special-casing for this Democrat without a listed party: {}".format(leg_name)
                 party = 'Democratic'
-            elif leg_name in ('James W. Mathis', 'J. Walter Michel'):
+            elif leg_name in ('James W. Mathis', 'Donnie Scoggin', 'John Glen Corley'):
                 assert not party, "Remove special-casing for this Republican without a listed party: {}".format(leg_name)
                 party = 'Republican'
             elif party == 'D':


### PR DESCRIPTION
MS legislator scrape is failing due to new legislators w/out parties. This fixes it.