### PR TITLE
AR: fix for crazy stray float in bulk actions file

### DIFF
--- a/openstates/ar/bills.py
+++ b/openstates/ar/bills.py
@@ -99,6 +99,8 @@ class ARBillScraper(BillScraper):
             # and negative offsets
             bill_id = "%s%s %s" % (row[1], row[2], row[3])
             actor = {'HU': 'lower', 'SU': 'upper'}[row[-5].upper()]
+            # manual fix for crazy time value
+            row[6] = row[6].replace('.520000000', '')
             date = datetime.datetime.strptime(row[6], "%Y-%m-%d %H:%M:%S")
             action = ','.join(row[7:-5])
 


### PR DESCRIPTION
Ar has this stray datetime that ends in .520000000 in their bulk data file (and only one). This is a manual fix. If it happens again I'll look into a more robust solution.