### PR TITLE
Fix HTMX links in NJ

### DIFF
--- a/openstates/nj/bills.py
+++ b/openstates/nj/bills.py
@@ -240,11 +240,11 @@ class NJBillScraper(BillScraper, MDBMixin):
             if rec['Comment']:
                 doc_name += ' ' + rec['Comment']
 
-            if rec['DocType'] in self._version_types:
-                # Clean HTMX links.
-                if htm_url.endswith('HTMX'):
-                    htm_url = re.sub('X$', '', htm_url)
+            # Clean HTMX links.
+            if htm_url.endswith('HTMX'):
+                htm_url = re.sub('X$', '', htm_url)
 
+            if rec['DocType'] in self._version_types:
                 if htm_url.endswith('HTM'):
                     mimetype = 'text/html'
                 elif htm_url.endswith('wpd'):


### PR DESCRIPTION
NJ has some bad document URLs linked on the site (ending in HTMX when they should end in HTM), so fix them on all documents, not just certain types.