### PR TITLE
Add docker-compose config.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,29 +11,25 @@ Links
 * `Sunlight Labs <http://sunlightlabs.com>`_
 
 Getting Started
-====
+===============
 We use `Docker <https://www.docker.com/products/docker>`_ to provide a reproducible development environment. Make sure
 you have Docker installed.  Inside of the directory you cloned this project into::
 
-  docker build -t openstates/openstates .  # Flaky. Try running the command again if it fails.
-  docker run openstates/openstates <abbreviated state code>  # Scrapes the state indicated by the code e.g. "ny"
+  docker-compose build  # Flaky. Try running the command again if it fails.
+  docker-compose up database  # Starts the database
+  docker-compose run openstates <abbreviated state code>  # Scrapes the state indicated by the code e.g. "ny"
 
 This project runs on top of `billy <https://github.com/openstates/billy>`_, a scraping framework for government data.
 Our Docker container runs the ``billy-update`` command
 (`billy-update docs <http://billy.readthedocs.io/en/latest/scripts.html>`_) with whatever arguments you put at the end
 of ``docker run``. For example, you can limit the scrape to Tennessee's (tn) state senators using::
 
-  docker run openstates/openstates tn --upper --legislators
-
-You have your local changes included in the container by
-`mounting your clone directory <https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume>`_::
-  docker run -v `pwd`:/srv/openstates-web openstates/openstates [billy-update-args...]
-
+  docker-compose run openstates tn --upper --legislators
 
 Testing
-====
+=======
 To run all tests::
 
-  docker run --entrypoint=nosetests openstates/openstates /srv/openstates-web/openstates
+  docker-compose run --entrypoint=nosetests openstates /srv/openstates-web/openstates
 
 Note that Illinois (il) is the only state with tests right now.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "2"
+services:
+  openstates:
+    build: .
+    environment:
+      BILLY_MONGO_HOST: database
+    volumes:
+    - .:/srv/openstates-web
+    ports:
+    - "8000:8000"
+    depends_on:
+    - database
+  database:
+    image: mongo
+    ports:
+    - "27017:27017"


### PR DESCRIPTION
So that devs don't have to run a separate local mongo, and to make the quickstart Just Work.