### PR TITLE
ID: don't word break committee sponsors

### DIFF
--- a/openstates/id/bills.py
+++ b/openstates/id/bills.py
@@ -218,10 +218,13 @@ class IDBillScraper(BillScraper):
         sponsor_lists = bill_tables[0].text_content().split('by')
         if len(sponsor_lists) > 1:
             for sponsors in sponsor_lists[1:]:
-                for person in _split(sponsors):
-                    person = person.strip()
-                    if person != "":
-                        bill.add_sponsor('primary', person)
+                if 'COMMITTEE' in sponsors.upper():
+                    bill.add_sponsor('primary', sponsors.strip())
+                else:
+                    for person in _split(sponsors):
+                        person = person.strip()
+                        if person != "":
+                            bill.add_sponsor('primary', person)
 
         actor = chamber
         last_date = None


### PR DESCRIPTION
ID was incorrectly breaking committee sponsors on space, so you would get "Revenue" "Taxation" as sponsors on "Revenue and Taxation Committee". This fixes that.

I'm assuming here that multiple committees can't sponsor a bill in ID, and there aren't any this session or last. If there's a counter-example let me know and i'll PR a more complicated regex.