### PR TITLE
MO: Use new senate listings page

### DIFF
--- a/openstates/mo/legislators.py
+++ b/openstates/mo/legislators.py
@@ -10,7 +10,9 @@ class MOLegislatorScraper(LegislatorScraper):
                             'Jefferson City, MO 65101')
     # senators_url = 'http://www.senate.mo.gov/{}info/senalpha.htm'
     # ^^^^^^^^^^^ pre-2013 URL. Keep if we need to scrape old pages.
-    _senators_url = 'http://www.senate.mo.gov/CurrentRoster.htm'
+    # _senators_url = 'http://www.senate.mo.gov/CurrentRoster.htm'
+    # ^^^^^^^^^^^ pre-2017 URL. Keep if we need to scrape the old pages.
+    _senators_url = 'http://www.senate.mo.gov/senators-listing/'
     _senator_details_url = 'http://www.senate.mo.gov/mem{:02d}'
     _reps_url = 'http://www.house.mo.gov/member.aspx'
     _rep_details_url = 'http://www.house.mo.gov/member.aspx?district={}'
@@ -29,13 +31,15 @@ class MOLegislatorScraper(LegislatorScraper):
         source_url = url
         page = self.get(url).text
         page = lxml.html.fromstring(page)
-        table = page.xpath('//*[@id="mainContent"]/table//table/tr')
+        table = page.xpath('//*[@id="content-2"]//table//tr')
         rowcount = 0
         for tr in table:
             rowcount += 1
+
             # the first two rows are headers, skip:
-            if rowcount < 2:
+            if rowcount <= 2:
                 continue
+
             tds = tr.xpath('td')
             full_name = tds[0].xpath('div/a')[0].text_content().strip()
 
@@ -63,7 +67,7 @@ class MOLegislatorScraper(LegislatorScraper):
             leg.add_source(url)
 
             page = lxml.html.fromstring(details_page)
-            photo_url = page.xpath('//img[contains(@src, "uploads")]/@src')[0]
+            photo_url = page.xpath('//*[@id="content-2"]//img[contains(@src, "uploads")]/@src')[0]
 
             contact_info = [
                 line.strip()


### PR DESCRIPTION
Switch the scraper for the MO senate from http://www.senate.mo.gov/CurrentRoster.htm to http://www.senate.mo.gov/senators-listing/.

The relative position of the table on the new listing page is differentt, but the columns of the table, and the structure of the content within each column is exactly the same.

`if rowcount < 2:` has been changed to `if rowcount <= 2:`. This line of code, as indicated by the comments, is meant to skip the first two rows of the table, both of which are headers. But using strictly `<`, the second row has `rowcount=2` and is not skipped. I don't know if/how this functioned in the original scrape, but have confirmed that with this change, the first row "Dan Brown" is scraped correctly, and without the scrape fails.

Verifying the output, I noticed that the photo_url was being returned as http://www.senate.mo.gov/17web/wp-content/uploads/2015/11/301px-Seal_of_the_Senate_of_Missouri_svg-e1448041814274.png, which links to the state seal.  I've updated the photo_url selector to be more specific, and it now correctly returns the member photo url.