### PR TITLE
NJ: Fix for missing committees

### DIFF
--- a/openstates/nj/committees.py
+++ b/openstates/nj/committees.py
@@ -48,4 +48,5 @@ class NJCommitteeScraper(CommitteeScraper, MDBMixin):
                 role = POSITIONS[member_rec["Position_on_Committee"]]
                 comm_name.add_member(leg, role=role)
 
-        self.save_committee(comm_name)
+        for comm in comm_dictionary.itervalues():
+            self.save_committee(comm)


### PR DESCRIPTION
Only one committee was ever saved per session, because `save_committee` was only being called once at the end of the script.  This updates the script to iterate over the scraped committees at the end of the script and save each one.