### PR TITLE
WV: Allow scraper to also pull Independent party

### DIFF
--- a/openstates/wv/legislators.py
+++ b/openstates/wv/legislators.py
@@ -44,12 +44,14 @@ class WVLegislatorScraper(LegislatorScraper):
         district = page.xpath('//h1[contains(., "DISTRICT")]/text()').pop().split()[1].strip().lstrip('0')
 
         party = page.xpath('//h2').pop().text_content()
-        party = re.search(r'\((R|D)[ \-\]]', party).group(1)
+        party = re.search(r'\((R|D|I)[ \-\]]', party).group(1)
 
         if party == 'D':
             party = 'Democratic'
         elif party == 'R':
             party = 'Republican'
+        elif party == 'I':
+            party = 'Independent'
 
         photo_url = page.xpath(
             "//img[contains(@src, 'images/members/')]")[0].attrib['src']


### PR DESCRIPTION
Scraper for WV has been failing for past few days. This small fix allows the scraper to also look for the I standing for Independent party. 