### PR TITLE
KS: Update parser for committee chair name to account for no FULLNAME

### DIFF
--- a/openstates/ks/committees.py
+++ b/openstates/ks/committees.py
@@ -46,7 +46,11 @@ class KSCommitteeScraper(CommitteeScraper):
                     continue
                 details = json.loads(detail_json)['content']
                 for chair in details['CHAIR']:
-                    committee.add_member(chair['FULLNAME'], 'chairman')
+                    if chair.get('FULLNAME', None):
+                        chair_name = chair['FULLNAME']
+                    else:
+                        chair_name = self.parse_kpid(chair['KPID'])
+                    committee.add_member(chair_name, 'chairman')
                 for vicechair in details['VICECHAIR']:
                     committee.add_member(vicechair['FULLNAME'], 'vice-chairman')
                 for rankedmember in details['RMMEM']:
@@ -60,3 +64,7 @@ class KSCommitteeScraper(CommitteeScraper):
                 else:
                     committee.add_source(com_url)
                     self.save_committee(committee)
+
+    def parse_kpid(self, kpid):
+        kpid_parts = kpid.split('_')
+        return ' '.join(reversed(kpid_parts[1:-1])).title()

--- a/openstates/ks/committees.py
+++ b/openstates/ks/committees.py
@@ -66,5 +66,11 @@ class KSCommitteeScraper(CommitteeScraper):
                     self.save_committee(committee)
 
     def parse_kpid(self, kpid):
+        """
+        Helper function to parse KPID given in data when FULLNAME is not available.
+
+        :param kpid: str, pre_formatted identifier in the format type_family_given_number
+        :return: str, formatted Fullname from id
+        """
         kpid_parts = kpid.split('_')
         return ' '.join(reversed(kpid_parts[1:-1])).title()


### PR DESCRIPTION
## Purpose
Fix for #1260

The KS scraper was breaking on Committee documents like [this one](http://www.kslegislature.org/li/api/v7/rev-1/ctte/ctte_hcsf_1/)

```
...
APPOINTMENTS: [ ],
CHAIR: [
    {
        KPID: "nonleg_hayzlett_gary_1"
    }
],
...
```
...because the scraper was looking for a `FULLNAME` key. 

## Changes
Instead, if there's no fullname provided for the committee info, parse the KPID provided in a bit of a rudimentary way, assuming a standard format for the ID is consistent. In this case, seems like the committee chair was NOT a legislator and so the full information was not provided. However, info could be gotten out of a (hopefully) consistently formed ID.
