### PR TITLE
CO: Fix off-by-one error keepign some CO bills from being scraped

### DIFF
--- a/openstates/co/bills.py
+++ b/openstates/co/bills.py
@@ -43,7 +43,7 @@ class COBillScraper(BillScraper, LXMLMixin):
 
         # We already have the first page load, so just grab later pages
         if max_page > 1:
-            for i in range(2, max_page + 1):
+            for i in range(1, max_page):
                 self.scrape_bill_list(session, chamber, i)
 
     def scrape_bill_list(self, session, chamber, pageNumber):


### PR DESCRIPTION
CO's bill scraper had an off-by-one error that was causing one page of results (25 bills) not to get scraped. 