### PR TITLE
Fix TX lower committee exception #1325

### DIFF
--- a/openstates/utils/lxmlize.py
+++ b/openstates/utils/lxmlize.py
@@ -1,6 +1,6 @@
 import requests
 import lxml.html
-
+from lxml.html import HtmlElement
 
 class LXMLMixin(object):
     """Mixin for adding LXML helper functions to Open States code."""
@@ -18,7 +18,7 @@ class LXMLMixin(object):
             # which have a `get` method defined.
             response = self.get(url)
         except requests.exceptions.SSLError:
-            self.warning('`self.lxmlize()` failed due to SSL error, trying'\
+            self.warning('`self.lxmlize()` failed due to SSL error, trying'
                 'an unverified `self.get()` (i.e. `requests.get()`)')
             response = self.get(url, verify=False)
 
@@ -61,4 +61,9 @@ class LXMLMixin(object):
         Returns:
             List[Element]: All nodes found that match the query.
         """
-        return base_node.xpath(xpath_query)
+        if isinstance(base_node, HtmlElement):
+            return base_node.xpath(xpath_query)
+        else:
+            self.logger.warning("Invalid type for base_node: {}"
+                                 .format(type(base_node)))
+            return []


### PR DESCRIPTION
#1325  There are two commits in this pull request, both can independently fix the lower committee scraper's exception.  Pick one or both depending on how broad you feel the fix for this should go.

The commit to committees.py will check if the members page does not contain the members table and skip the member enumeration routine, this avoids calling get_nodes with a None type object and contains the change to the TX module.

The other commit lxmlize addresses another bug which was actually throwing the exception for this issue.  lxmlize.get_nodes does not check the base_node for sanity before trying to access its attributes.  Since the function is suppose to return a list of elements, I am returning an empty list instead of throwing an exception(as well as logging a warning).  Looking around the other state modules, most things are not checking the validity of what is being passed into get_nodes.  This fix will either help prevent future crashes or make data collection errors less obvious depending on how strictly the output of Billy is being monitored.