### PR TITLE
OR: Handle valid unicode characters as well as unicode encoded names 1330

### DIFF
--- a/openstates/or/legislators.py
+++ b/openstates/or/legislators.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+import re
+import unicodedata
 from billy.scrape.legislators import LegislatorScraper, Legislator
 from openstates.utils import LXMLMixin
-import re
 
 
 def itergraphs(elements, break_):
@@ -41,10 +43,15 @@ class ORLegislatorScraper(LegislatorScraper, LXMLMixin):
                 continue
 
             h2, = h2s
+            name = h2.text
             # Need to remove weird Unicode spaces from their names
-            name = " ".join(h2.text.split())
-            name = re.sub(r'^\W?(Senator|Representative)\W?(?=[A-Z])', "", name)
+            if isinstance(name, unicode):
+                name = "".join(c for c in name
+                               if unicodedata.category(c)[0] != "C")
 
+            name = " ".join(name.split())
+            name = re.sub(r'^\W?(Senator|Representative)\W?(?=[A-Z])',
+                          "", name)
             photo_block, = photo_block
             # (The <td> before ours was the photo)
             img, = photo_block.xpath("*")


### PR DESCRIPTION
#1330 The method that was attempting to remove non-printable characters did not handle the cases where some non-printable characters were not removed via strip(), due to this [issue](https://bugs.python.org/issue13391).  The character being reported in this issue was the unicode zero-width space, this PR removes all control-character from the name and leaves normal unicode characters in place.