### PR TITLE
MO: Make "Assigned bills" filter for committee links case insensitive

### DIFF
--- a/openstates/mo/committees.py
+++ b/openstates/mo/committees.py
@@ -21,6 +21,10 @@ class MOCommitteeScraper(CommitteeScraper, LXMLMixin):
         sessions = term.split('-')
 
         for session in sessions:
+            # The second session in a two year term might not have details yet
+            if session not in self.metadata['session_details']:
+                continue
+
             session_start_date = self.metadata['session_details'][session]\
                 ['start_date']
 
@@ -54,7 +58,8 @@ class MOCommitteeScraper(CommitteeScraper, LXMLMixin):
             '//div[@id = "{}"]//p/a'.format(comm_container_id))
 
         for comm_link in comm_links:
-            if "Assigned bills" in comm_link.text_content():
+            # Normalize to uppercase - varies between "Assigned bills" and "Assigned Bills"
+            if "ASSIGNED BILLS" in comm_link.text_content().upper():
                 continue
 
             comm_link = comm_link.attrib['href']


### PR DESCRIPTION
In addition to "Assigned bills", the link text was also sometimes "Assigned Bills".  This was allowing some links to committee bills to be used as the committee details page, which caused the script to crash.

This also skips sessions without any session details from being scraped.  The script was crashing when it tried to process the 2018 session of the "2017-2018" term, which is not available yet.

Closes #1319