### PR TITLE
KS: Rate limit API requests for committee scraper

### DIFF
--- a/openstates/ks/committees.py
+++ b/openstates/ks/committees.py
@@ -8,6 +8,11 @@ from billy.scrape.committees import Committee, CommitteeScraper
 
 import ksapi
 
+# The recommendation is to have one API reqeust every 5 seconds.
+# We still had BadStatus errors (maybe from their 429 page) at that rate, so reduced to once every 6 seconds
+KANSAS_API_MAXIMUM_RPM = 60 / 6
+
+
 class KSCommitteeScraper(CommitteeScraper):
     jurisdiction = 'ks'
     latest_only = True
@@ -15,6 +20,9 @@ class KSCommitteeScraper(CommitteeScraper):
     def scrape(self, chamber, term):
         # some committees, 500, let them go
         self.retry_attempts = 0
+
+        if self.requests_per_minute > KANSAS_API_MAXIMUM_RPM:
+            self.requests_per_minute = KANSAS_API_MAXIMUM_RPM
 
         self.scrape_current(chamber, term)
 


### PR DESCRIPTION
Data was missing from the Open States scrape of KS committees.  Running locally without any rate limiting, some committees had warnings like the following:

```
02:02:47 WARNING billy: error fetching committee http://www.kslegislature.org/li/api/v7/rev-1/ctte/ctte_sub_public_safety_subcommittee_ways_and_means_1/
```

These warnings may have gone unnoticed, allowing the scrape to finish without updating the data for some committees.

Copying the link quickly after it was printed to see the response in the browser, I 429 error code and a message instructing me to limit requests to once every 3-5 seconds.

Avoids 429 errors for the KS api by rate limiting to one request every 6 seconds (10 RPM), which was the lowest time I got to work without fail in dev.

While other KS scrapers use the KS api, the rest only issue a single request, not a single request per item, and so don't need to be rate limited.

Closes #1316