### PR TITLE
FL: Added assertion case for TBD office addresses.

### DIFF
--- a/openstates/fl/legislators.py
+++ b/openstates/fl/legislators.py
@@ -42,7 +42,7 @@ class FLLegislatorScraper(LegislatorScraper):
                 phone = None
             if re.search(r'(?i)open\s+\w+day', address_lines[0]):
                 address_lines = address_lines[1: ]
-            assert ", FL" in address_lines[-1]
+            assert ", FL" in address_lines[-1] or address_lines[-1] == 'TBD'
             address = "\n".join(address_lines)
             address = re.sub(r'\s{2,}', " ", address)
 


### PR DESCRIPTION
The assertion in question was causing the legislator scraper to hang on Senator Book (http://www.flsenate.gov/Senators/s32) as her district office address is TBD.