### PR TITLE
WI: Fixed bill vote parser, and made related document xpath stricter

### DIFF
--- a/openstates/wi/bills.py
+++ b/openstates/wi/bills.py
@@ -176,7 +176,7 @@ class WIBillScraper(BillScraper):
                 extra_doc_url = a.get('href')
                 extra_doc = lxml.html.fromstring(self.get(extra_doc_url).text)
                 extra_doc.make_links_absolute(extra_doc_url)
-                for extra_a in extra_doc.xpath('//li//a'):
+                for extra_a in extra_doc.xpath('//ul[@class="docLinks"]/li//a'):
                     if extra_a.text:
                         bill.add_document(extra_a.text, extra_a.get('href'))
             else:
@@ -333,7 +333,7 @@ class WIBillScraper(BillScraper):
 
     def add_house_votes(self, vote, url):
         try:
-            html = self.get(url).text
+            html = self.get(url).content
         except scrapelib.HTTPError:
             self.warning('No House Votes found for %s' % url)
             return
@@ -341,7 +341,8 @@ class WIBillScraper(BillScraper):
         doc = lxml.html.fromstring(html)
 
         header_td = doc.xpath('//div/p[text()[contains(., "AYES")]]')[0].text_content()
-        ayes_nays = re.findall('AYES - (\d+) NAYS - (\d+)', header_td)
+        ayes_nays = re.findall(r'AYES - (\d+).*NAYS - (\d+).*', header_td)
+
         vote['yes_count'] = int(ayes_nays[0][0])
         vote['no_count'] = int(ayes_nays[0][1])
 


### PR DESCRIPTION
Junk characters in the wisconsin vote pages [example](http://docs.legis.wisconsin.gov/2017/related/votes/assembly/av0002) were causing the vote parsing regex to fail. 

The related documents function was grabbing too many site links due to an HTML format change, so I made it stricter so it doesn't add site navigation items as related documents.