### PR TITLE
Fix off-by one. upper chamber is >= 5000, not > 5000

### DIFF
--- a/openstates/wa/bills.py
+++ b/openstates/wa/bills.py
@@ -208,7 +208,7 @@ class WABillScraper(BillScraper, LXMLMixin):
 
                 # Senate bills are numbered starting at 5000,
                 # House at 1000
-                if bill_num > 5000:
+                if bill_num >= 5000:
                     bill_chamber = 'upper'
                 else:
                     bill_chamber = 'lower'


### PR DESCRIPTION
See for example:  http://app.leg.wa.gov/billsummary?BillNumber=5000&Year=2017

Current Bill Id WAB00013657 has this wrong (so this fix may require cleaning the cache)