### PR TITLE
MA_find_cosponsor_1366

### DIFF
--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -139,9 +139,8 @@ class MABillScraper(BillScraper):
             sponsor = sponsor[0].strip()
             bill.add_sponsor('primary', sponsor)
 
-        has_cosponsor = page.xpath('//a[starts-with(normalize-space(.),"Petitioners")]')
-        if has_cosponsor:
-            self.scrape_cosponsors(bill, bill_url)
+        self.scrape_cosponsors(bill, bill_url)
+            
 
         version = page.xpath("//div[contains(@class, 'modalBtnGroup')]/a[contains(text(), 'Download PDF') and not(@disabled)]/@href")
         if version:


### PR DESCRIPTION
#1366 Due to a bug on the MA page, always make a call for cosponsors since we can no longer intelligently find it.  Bills without cosponsors will not fail/except due to this change

@jamesturk You might want to hold off on merging this for a few days.  I contacted the webmaster of the MA website and reported the bug.  I'm submitting the PR now to clean up my branches but would like to give them a chance to respond and fix the issue before we commit to always trying to pull the cosponsor page.