### PR TITLE
Expose billy data and cache.

### DIFF
--- a/billy_settings.py
+++ b/billy_settings.py
@@ -1,24 +1,20 @@
 import os
 
-from os.path import abspath, dirname, join
-
 import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # This shims around folks that have openstates/ on virtualenv's .pth, but
 # not the root. This throws openstates.utils off, and isn't worth fiddling
 # that much with.
 
-SCRAPER_PATHS=[os.path.join(os.getcwd(), 'openstates')]
+SCRAPER_PATHS = [os.path.join(os.getcwd(), 'openstates')]
 MONGO_HOST = os.environ.get('BILLY_MONGO_HOST', 'localhost')
 MONGO_PORT = 27017
 MONGO_DATABASE = 'fiftystates'
 
-BILLY_MANUAL_DATA_DIR = os.environ.get('BILLY_MANUAL_DATA_DIR')
-if BILLY_MANUAL_DATA_DIR is None:
-    BILLY_MANUAL_DATA_DIR = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)),
-        "manual_data",
-    )
+here = os.path.abspath(os.path.dirname(__file__))
+BILLY_DATA_DIR = os.environ.get('BILLY_DATA_DIR', os.path.join(here, 'data'))
+BILLY_CACHE_DIR = os.environ.get('BILLY_CACHE_DIR', os.path.join(here, 'cache'))
+BILLY_MANUAL_DATA_DIR = os.environ.get('BILLY_MANUAL_DATA_DIR', os.path.join(here, 'manual_data'))
 
 LEGISLATOR_FILTERS = {
     "billy.importers.filters.single_space_filter": [


### PR DESCRIPTION
Resolves #1371.

For backwards compatibility, we could only set the data and cache paths if provided in the environment and pass them from docker-compose, but IMO it makes more sense to locate data, cache, and manual data in the same place.