### PR TITLE
Run mysql for ca scraper with docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     environment:
     - BILLY_MONGO_HOST=database
     - MYSQL_HOST=mysql
-    - CA_DOWNLOAD=true
     - NEW_YORK_API_KEY
     - INDIANA_API_KEY
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: .
     environment:
     - BILLY_MONGO_HOST=database
+    - MYSQL_HOST=mysql
+    - CA_DOWNLOAD=true
     - NEW_YORK_API_KEY
     - INDIANA_API_KEY
     volumes:
@@ -16,3 +18,9 @@ services:
     image: mongo
     ports:
     - "27017:27017"
+  mysql:
+    image: mysql
+    ports:
+    - "3306:3306"
+    environment:
+    - MYSQL_DATABASE=capublic

--- a/openstates/ca/README.rst
+++ b/openstates/ca/README.rst
@@ -1,0 +1,14 @@
+Getting Started
+===============
+
+- Run mysql via docker-compose: ::
+
+    $ docker-compose up mysql
+
+- Download and ingest the data: ::
+
+    $ docker-compose run --entrypoint python openstates -m openstates.ca.download
+
+- Scrape the data: ::
+
+    $ docker-compose run openstates ca

--- a/openstates/ca/__init__.py
+++ b/openstates/ca/__init__.py
@@ -1,3 +1,4 @@
+import os
 import datetime
 import lxml.html
 from .bills import CABillScraper
@@ -13,7 +14,7 @@ metadata = dict(
     capitol_timezone='America/Los_Angeles',
     legislature_name='California State Legislature',
     legislature_url='http://www.legislature.ca.gov/',
-    chambers = {
+    chambers={
         'upper': {'name': 'Senate', 'title': 'Senator'},
         'lower': {'name': 'Assembly', 'title': 'Assemblymember'},
     },
@@ -157,7 +158,7 @@ metadata = dict(
         '1997-1998',
         '1995-1996',
         '1993-1994'
-        ]
+    ]
 )
 
 
@@ -180,3 +181,11 @@ def extract_text(doc, data):
         div = doc.xpath(xpath)
         if div:
             return div[0].text_content()
+
+
+if os.environ.get('CA_DOWNLOAD'):
+    from . import download
+    download.db_drop()
+    download.db_create()
+    contents = download.get_contents()
+    download.get_current_year(contents)

--- a/openstates/ca/__init__.py
+++ b/openstates/ca/__init__.py
@@ -1,4 +1,3 @@
-import os
 import datetime
 import lxml.html
 from .bills import CABillScraper
@@ -181,11 +180,3 @@ def extract_text(doc, data):
         div = doc.xpath(xpath)
         if div:
             return div[0].text_content()
-
-
-if os.environ.get('CA_DOWNLOAD'):
-    from . import download
-    download.db_drop()
-    download.db_create()
-    contents = download.get_contents()
-    download.get_current_year(contents)

--- a/openstates/ca/bills.py
+++ b/openstates/ca/bills.py
@@ -257,9 +257,13 @@ class CABillScraper(BillScraper):
 
     _tz = pytz.timezone('US/Pacific')
 
-    def __init__(self, metadata, host='localhost', user=None, pw=None,
+    def __init__(self, metadata, host=None, user=None, pw=None,
                  db='capublic', **kwargs):
         super(CABillScraper, self).__init__(metadata, **kwargs)
+
+        if host is None:
+            host = os.environ.get('MYSQL_HOST',
+                                  getattr(settings, 'MYSQL_HOST', 'localhost'))
 
         if user is None:
             user = os.environ.get('MYSQL_USER',

--- a/openstates/ca/download.py
+++ b/openstates/ca/download.py
@@ -27,6 +27,9 @@ import _mysql_exceptions
 from billy.core import settings
 
 
+MYSQL_HOST = getattr(settings, 'MYSQL_HOST', 'localhost')
+MYSQL_HOST = os.environ.get('MYSQL_HOST', MYSQL_HOST)
+
 MYSQL_USER = getattr(settings, 'MYSQL_USER', 'root')
 MYSQL_USER = os.environ.get('MYSQL_USER', MYSQL_USER)
 
@@ -64,7 +67,7 @@ def db_drop():
     logger.info('dropping capublic...')
 
     try:
-        connection = MySQLdb.connect(user=MYSQL_USER, passwd=MYSQL_PASSWORD, db='capublic')
+        connection = MySQLdb.connect(host=MYSQL_HOST, user=MYSQL_USER, passwd=MYSQL_PASSWORD, db='capublic')
     except _mysql_exceptions.OperationalError:
         # The database doesn't exist.
         logger.info('...no such database. Bailing.')
@@ -169,7 +172,7 @@ def load(folder, sql_name=partial(re.compile(r'\.dat$').sub, '.sql')):
     logger.info('Loading data from %s...' % folder)
     os.chdir(folder)
 
-    connection = MySQLdb.connect(user=MYSQL_USER, passwd=MYSQL_PASSWORD,
+    connection = MySQLdb.connect(host=MYSQL_HOST, user=MYSQL_USER, passwd=MYSQL_PASSWORD,
                                  db='capublic', local_infile=1)
     connection.autocommit(True)
 
@@ -232,7 +235,7 @@ def delete_session(session_year):
 
     logger.info('Deleting all data for session year %s...' % session_year)
 
-    connection = MySQLdb.connect(user=MYSQL_USER, passwd=MYSQL_PASSWORD,
+    connection = MySQLdb.connect(host=MYSQL_HOST, user=MYSQL_USER, passwd=MYSQL_PASSWORD,
                                  db='capublic')
     connection.autocommit(True)
     cursor = connection.cursor()
@@ -263,7 +266,7 @@ def db_create():
         # so we have to split them up.
         sql_statements = f.read().split(';')
 
-    connection = MySQLdb.connect(user=MYSQL_USER, passwd=MYSQL_PASSWORD)
+    connection = MySQLdb.connect(host=MYSQL_HOST, user=MYSQL_USER, passwd=MYSQL_PASSWORD)
     connection.autocommit(True)
     cursor = connection.cursor()
 

--- a/openstates/ca/models.py
+++ b/openstates/ca/models.py
@@ -1,5 +1,5 @@
-from sqlalchemy import (Table, Column, Integer, String, ForeignKey,
-                        DateTime, Numeric, desc, UnicodeText)
+from sqlalchemy import (Column, Integer, String, ForeignKey,
+                        DateTime, Numeric, UnicodeText)
 from sqlalchemy.sql import and_
 from sqlalchemy.orm import backref, relation
 from sqlalchemy.ext.declarative import declarative_base
@@ -69,7 +69,7 @@ class CABillVersion(Base):
 
     @property
     def xml(self):
-        if not '_xml' in self.__dict__:
+        if '_xml' not in self.__dict__:
             self._xml = etree.fromstring(self.bill_xml.encode('utf-8'),
                                          etree.XMLParser(recover=True))
         return self._xml


### PR DESCRIPTION
Note: optionally running the CA downloads in `__init__` feels like a hack. Anybody have a better idea? Maybe we expose another command in docker-compose to load the CA database?