### PR TITLE
WI: Ignore january special session with no bills, fix 2017 end date

### DIFF
--- a/openstates/wi/__init__.py
+++ b/openstates/wi/__init__.py
@@ -134,6 +134,7 @@ metadata = {
                       'events', 
                       'influenceexplorer'],
     '_ignored_scraped_sessions': [
+        # The WI Website has multiple special sessions in the system with no data.
         'January 2017 Special Session',
         'February 2015 Extraordinary Session',
         '2007 Regular Session', 'April 2008 Special Session',

--- a/openstates/wi/__init__.py
+++ b/openstates/wi/__init__.py
@@ -124,7 +124,7 @@ metadata = {
         },
         '2017 Regular Session': {
             'start_date': datetime.date(2017, 1, 3),
-            'end_date': datetime.date(2017, 1, 11),
+            'end_date': datetime.date(2018, 5, 23),
             'type': 'primary',
             'display_name': '2017 Regular Session',
             '_scraped_name': '2017 Regular Session',
@@ -134,6 +134,7 @@ metadata = {
                       'events', 
                       'influenceexplorer'],
     '_ignored_scraped_sessions': [
+        'January 2017 Special Session',
         'February 2015 Extraordinary Session',
         '2007 Regular Session', 'April 2008 Special Session',
         'March 2008 Special Session', 'December 2007 Special Session',


### PR DESCRIPTION
WI Added their january special to the website which broke the bills scraper. 

There don't seem to be any bills [here](http://docs.legis.wisconsin.gov/2017/proposals/JR7/) -- given the dates i'm wondering if they didn't make it to the website or if they just got rolled into the Regular.

If they do post the bills back later, let me know and I'll add it as a real session.