### PR TITLE
CO: Fixed broken scraper

### DIFF
--- a/openstates/co/actions.py
+++ b/openstates/co/actions.py
@@ -71,8 +71,11 @@ rules = (
     Rule(u'(?i)refer (un)?amended to (?P<committees>.+)',
          [u'committee:referred']),
     Rule(u'(?i)\S+ Committee on (?P<committees>.+?) Refer (un)amended'),
+    Rule(u'Assigned to (<?P<committees>.+?)', 'committee:referred'),
     Rule(u'Second Reading Passed', [u'bill:reading:2']),
-    Rule(u'Third Reading Passed', ['bill:reading:3', 'bill:passed'])
+    Rule(u'Third Reading Passed', ['bill:reading:3', 'bill:passed']),
+    Rule(u'to Senate Committee of the Whole', 'committee:passed', actor='upper'),
+    Rule(u'to House Committee of the Whole', 'committee:passed', actor='lower')
     )
 
 committees_rgx = '(%s)' % '|'.join(

--- a/openstates/co/bills.py
+++ b/openstates/co/bills.py
@@ -110,6 +110,7 @@ class COBillScraper(BillScraper, LXMLMixin):
         self.scrape_versions(bill, page)
         self.scrape_research_notes(bill, page)
         self.scrape_fiscal_notes(bill, page)
+        self.scrape_committee_report(bill, page)
         self.scrape_votes(bill, page)
 
         self.save_bill(bill)
@@ -195,6 +196,12 @@ class COBillScraper(BillScraper, LXMLMixin):
             note_url = note[0]
             bill.add_document("Research Note", note_url, 'application/pdf')
 
+    def scrape_committee_report(self, bill, page):
+        note = page.xpath('//a[text()="Committee Report"]/@href')
+        if note:
+            note_url = note[0]
+            bill.add_version("Committee Amendment", note_url, 'application/pdf')
+
     def scrape_votes(self, bill, page):
         votes = page.xpath('//div[@id="bill-documents-tabs3"]//table//tbody//tr')
 
@@ -217,7 +224,8 @@ class COBillScraper(BillScraper, LXMLMixin):
             elif 'House' in header.group('committee'):
                 chamber = 'lower'
             else:
-                self.warning("No committee for %s" % header.group('committee'))
+                self.warning("No chamber for %s" % header.group('committee'))
+                chamber = bill['chamber']
 
             date = dt.datetime.strptime(header.group('date'), '%m/%d/%Y')
 


### PR DESCRIPTION
Fix failing scrape by assuming votes without a chamber are in the bills chamber.

Added committee amendments to versions, which we weren't collecting. Added a few more action categories.

I believe this will resolve #1379 by allowing the broken roll call proceed.