### PR TITLE
Senator Emails are mailforms - CT State Legisaltors #1217

### DIFF
--- a/openstates/ct/legislators.py
+++ b/openstates/ct/legislators.py
@@ -80,7 +80,7 @@ class CTLegislatorScraper(LegislatorScraper):
                 row['capitol street address'], row['room number'])
             email = row['email'].strip()
             if "@" not in email:
-                if not email or email.endswith('mailform.php'):
+                if not email or email.startswith('http://') or email.startswith('https://'):
                     email = None
                 else:
                     raise ValueError("Problematic email found: {}".format(email))

--- a/openstates/ct/legislators.py
+++ b/openstates/ct/legislators.py
@@ -78,9 +78,13 @@ class CTLegislatorScraper(LegislatorScraper):
 
             office_address = "%s\nRoom %s\nHartford, CT 06106" % (
                 row['capitol street address'], row['room number'])
+            extra_office_fields = dict()
             email = row['email'].strip()
             if "@" not in email:
-                if not email or email.startswith('http://') or email.startswith('https://'):
+                if not email:
+                    email = None
+                elif email.startswith('http://') or email.startswith('https://'):
+                    extra_office_fields['contact_form'] = email
                     email = None
                 else:
                     raise ValueError("Problematic email found: {}".format(email))
@@ -88,7 +92,8 @@ class CTLegislatorScraper(LegislatorScraper):
                            address=office_address,
                            phone=row['capitol phone'],
                            fax=(row['fax'].strip() or None),
-                           email=email)
+                           email=email,
+                           **extra_office_fields)
 
             home_address = "{}\n{}, {} {}".format(
                 row['home street address'],


### PR DESCRIPTION
Re https://github.com/openstates/openstates/issues/1217

CT Legislator scraper was raising an error on an invalid email address. The scraper was trying to skip contact form URLs in the email field, but looks like a new one was added to the data that looks different from the ones that were there before.

This patch handles all the contact form URLs found in the email field, putting None for email address if the value present is actually a contact form URL, and putting those contact form URLs into an extra field, "contact_form".