### PR TITLE
CO: Check for info in the vote header before trying to parse information

### DIFF
--- a/openstates/co/bills.py
+++ b/openstates/co/bills.py
@@ -221,6 +221,11 @@ class COBillScraper(BillScraper, LXMLMixin):
             header = re.search(r'(?P<date>\d{2}/\d{2}/\d{4})\s+\| (?P<committee>.*)',
                                parent_committee_row)
 
+            # Some vote headers have missing information, so we cannot save the vote information
+            if not header:
+                self.warning("No date and committee information available in the vote header.")
+                return
+
             if 'Senate' in header.group('committee'):
                 chamber = 'upper'
             elif 'House' in header.group('committee'):


### PR DESCRIPTION
if there's no info in the vote header, simply return and then no vote information will be saved. 

There were a few pages [like this one](http://leg.colorado.gov/bills/hb17-1045) that are supposed to have date and committee info in the blue header on the Committee Action page - instead there is just a blank '|' -- if this is the case, you can't seem to get the vote date from another
source, so just return nothing