### PR TITLE
Fix #1440 by allowing the code to accept a variety of party naming schemes. 

### DIFF
--- a/openstates/ma/legislators.py
+++ b/openstates/ma/legislators.py
@@ -78,9 +78,9 @@ class MALegislatorScraper(LegislatorScraper):
         party = party.strip()
         district = clean_district(district.strip())
 
-        if party == 'Democrat':
+        if party in ('D', 'Democrat', 'Democratic'):
             party = 'Democratic'
-        elif party == 'R':
+        elif party in ('R', 'Republican'):
             party = 'Republican'
         else:
             party = 'Other'


### PR DESCRIPTION
It seems MA has changed from R to Republican on their pages.