### PR TITLE
FL: Fix info log.

### DIFF
--- a/openstates/fl/bills.py
+++ b/openstates/fl/bills.py
@@ -511,7 +511,7 @@ class FlBillScraper(Scraper, Spatula):
         # TODO: there should probably be an easy way to do this in pupa
         if not session:
             session = self.jurisdiction.legislative_sessions[-1]['identifier']
-            self.info('no session specified, using', session)
+            self.info('no session specified, using %s', session)
 
         subject_url = ('http://www.leg.state.fl.us/data/session/{}/citator/Daily/subindex.pdf'
                        .format(session))


### PR DESCRIPTION
Fixes this error:

```
TypeError: not all arguments converted during string formatting
Call stack:
  File "/opt/openstates/venv-pupa//bin/pupa", line 11, in <module>
    load_entry_point('pupa', 'console_scripts', 'pupa')()
  File "/opt/openstates/venv-pupa/src/pupa/pupa/cli/__main__.py", line 68, in main
    subcommands[args.subcommand].handle(args, other)
  File "/opt/openstates/venv-pupa/src/pupa/pupa/cli/commands/update.py", line 288, in handle
    report['scrape'] = self.do_scrape(juris, args, scrapers)
  File "/opt/openstates/venv-pupa/src/pupa/pupa/cli/commands/update.py", line 166, in do_scrape
    report[scraper_name] = scraper.do_scrape(**scrape_args)
  File "/opt/openstates/venv-pupa/src/pupa/pupa/scrape/base.py", line 101, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/opt/openstates/openstates/openstates/fl/bills.py", line 514, in scrape
    self.info('no session specified, using {}', session)
  File "/usr/lib/python3.5/logging/__init__.py", line 1279, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.5/logging/__init__.py", line 1415, in _log
    self.handle(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 1425, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 1487, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.5/logging/__init__.py", line 855, in handle
    self.emit(record)
  File "/opt/openstates/venv-pupa/src/pupa/pupa/ext/ansistrm.py", line 65, in emit
    self.handleError(record)
Message: 'no session specified, using {}'
Arguments: ('2017',)
```