### PR TITLE
OK: Strip (mainsys) out of session listing

### DIFF
--- a/openstates/ok/__init__.py
+++ b/openstates/ok/__init__.py
@@ -67,7 +67,7 @@ metadata = dict(
          '2017-2018':
             {'display_name': '2017-2018 Regular Session',
              'session_id': '1700',
-             '_scraped_name': '2017 Regular Session(Mainsys)',
+             '_scraped_name': '2017 Regular Session',
             },
         },
     feature_flags=['subjects', 'influenceexplorer'],
@@ -95,9 +95,11 @@ metadata = dict(
 
 def session_list():
     from billy.scrape.utils import url_xpath
-    return url_xpath('http://webserver1.lsb.state.ok.us/WebApplication2/WebForm1.aspx',
-        "//select[@name='cbxSession']/option/text()")
-
+    sessions = url_xpath('http://webserver1.lsb.state.ok.us/WebApplication2/WebForm1.aspx',
+                        "//select[@name='cbxSession']/option/text()")
+    # OK Sometimes appends (Mainsys) to their session listings
+    sessions = [s.replace('(Mainsys)', '').strip() for s in sessions]
+    return sessions
 
 def extract_text(doc, data):
     return worddata_to_text(data)


### PR DESCRIPTION
OK has been putting (mainsys) after various sessions in their dropdown off and on for a few months. Rather than manually change it each time, filter it out of the session_list.

