### PR TITLE
Make generated pupa code flake8-compliant.

### DIFF
--- a/scripts/convert_metadata.py
+++ b/scripts/convert_metadata.py
@@ -44,8 +44,7 @@ def convert(state):
 
     lower_max, upper_max = get_districts(state)
 
-    tmpl = """import datetime
-from pupa.scrape import Jurisdiction, Organization
+    tmpl = """from pupa.scrape import Jurisdiction, Organization
 
 
 class {classname}(Jurisdiction):
@@ -60,9 +59,7 @@ class {classname}(Jurisdiction):
         {{'name': 'Democratic'}}
     ]
     legislative_sessions = {sessions}
-    ignored_scraped_sessions = [
-{ignored}
-    ]
+    ignored_scraped_sessions = {ignored}
 
     def get_organizations(self):
         legislature_name = "{legislature_name}"
@@ -112,13 +109,8 @@ class {classname}(Jurisdiction):
             s['end_date'] = v.get('end_date')
         sessions.append(s)
 
-    sessions = json.dumps(sessions, sort_keys=True, indent=4,
-                          cls=DatetimeEncoder, separators=(',', ': '))
-    sessions = sessions.replace('null', 'None')
-
-    ignored = '        ' + '\n        '.join(
-        repr(x) + ',' for x in metadata['_ignored_scraped_sessions']
-    )
+    sessions = indent_tail(format_json(sessions), 4)
+    ignored = indent_tail(format_json(metadata['_ignored_scraped_sessions']), 4)
 
     data = {
         'abbr': metadata['abbreviation'],
@@ -135,6 +127,22 @@ class {classname}(Jurisdiction):
         'upper_seats': upper_max,
     }
     print(tmpl.format(**data))
+
+
+def format_json(data):
+    return json.dumps(
+        data,
+        indent=4,
+        sort_keys=True,
+        cls=DatetimeEncoder,
+        separators=(',', ': '),
+    ).replace('null', 'None')
+
+
+def indent_tail(text, n):
+    padding = ' ' * n
+    lines = text.split('\n')
+    return '\n'.join([lines[0]] + [padding + line for line in lines[1:]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Skip unused `datetime` import
* Fix indentation on sessions and ignored sessions