### PR TITLE
CO: Allow versions without publish dates

### DIFF
--- a/openstates/co/bills.py
+++ b/openstates/co/bills.py
@@ -135,7 +135,10 @@ class COBillScraper(BillScraper, LXMLMixin):
 
         #skip the header row
         for version in versions:
-            version_date = version.xpath('td[1]/text()')[0].strip()
+            if version.xpath('td[1]/text()'):
+                version_date = version.xpath('td[1]/text()')[0].strip()
+            else:
+                version_date = 'None'
             #version_date = dt.datetime.strptime(version_date, '%m/%d/%Y')
             version_type = version.xpath('td[2]/text()')[0]
             version_url = version.xpath('td[3]/span/a/@href')[0]


### PR DESCRIPTION
CO Bill scraper was dying because they published a version without a pubdate.