### PR TITLE
Pull images from dockerhub.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,6 @@ Getting Started
 We use `Docker <https://www.docker.com/products/docker>`_ to provide a reproducible development environment. Make sure
 you have Docker installed.  Inside of the directory you cloned this project into::
 
-  docker-compose build  # Flaky. Try running the command again if it fails.
-  docker-compose up database  # Starts the database
   docker-compose run openstates <abbreviated state code>  # Scrapes the state indicated by the code e.g. "ny"
 
 This project runs on top of `billy <https://github.com/openstates/billy>`_, a scraping framework for government data.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   openstates:
-    build: .
+    image: openstates/openstates
     environment:
     - BILLY_MONGO_HOST=database
     - MYSQL_HOST=mysql
@@ -21,9 +21,7 @@ services:
     depends_on:
     - database
   scrape:
-    build:
-        context: .
-        dockerfile: Dockerfile-pupa
+    image: openstates/openstates-pupa
     environment:
     - BILLY_MONGO_HOST=database
     - MYSQL_HOST=mysql


### PR DESCRIPTION
I noticed some questions about building docker images on slack, and it occurred to me that there's no reason for most users to be building images in the first place. This patch pulls images from dockerhub instead of building, which is probably how I should have written this in the first place.