### PR TITLE
LA, GA, HI: fix blatant vote name issues

### DIFF
--- a/openstates/ga/bills.py
+++ b/openstates/ga/bills.py
@@ -190,7 +190,14 @@ class GABillScraper(BillScraper):
                             m = methods[how]
                         except KeyError:
                             m = vote.other
-                        m(whom['Name'])
+
+                        if whom['Name'].upper() == 'VACANT':
+                            name = whom['Name']
+                        else:
+                            # 'Name' contains a name followed by ", XXTH", e.g. "CALDWELL, JR., 55th"
+                            name, _ = whom['Name'].rsplit(', ', 1)
+
+                        m(name.strip())
 
                     bill.add_vote(vote)
 

--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -64,7 +64,8 @@ def split_specific_votes(voters):
         voters = voters.replace('Senator(s) ', '')
     elif voters.startswith('Representative(s)'):
         voters = voters.replace('Representative(s)', '')
-    return voters.split(', ')
+    # Remove trailing spaces and semicolons
+    return (v.rstrip(' ;') for v in voters.split(', '))
 
 class HIBillScraper(BillScraper):
 

--- a/openstates/la/bills.py
+++ b/openstates/la/bills.py
@@ -150,7 +150,6 @@ class LABillScraper(BillScraper, LXMLMixin):
         os.remove(temp_path)
 
         vote_type = None
-        total_re = re.compile('^Total--(\d+)$')
         body = html.xpath('string(/html/body)')
 
         date_match = re.search('Date: (\d{1,2}/\d{1,2}/\d{4})', body)
@@ -164,7 +163,8 @@ class LABillScraper(BillScraper, LXMLMixin):
 
         for line in body.replace(u'\xa0', '\n').split('\n'):
             line = line.replace('&nbsp;', '').strip()
-            if not line:
+            # Skip blank lines and "Total --"
+            if not line or 'Total --' in line:
                 continue
 
             if line in ('YEAS', 'NAYS', 'ABSENT'):
@@ -173,10 +173,7 @@ class LABillScraper(BillScraper, LXMLMixin):
             elif line in ('Total', '--'):
                 vote_type = None
             elif vote_type:
-                match = total_re.match(line)
-                if match:
-                    vote['%s_count' % vote_type] = int(match.group(1))
-                elif vote_type == 'yes':
+                if vote_type == 'yes':
                     vote.yes(line)
                 elif vote_type == 'no':
                     vote.no(line)


### PR DESCRIPTION
This removes noise from vote names for a few of the states highlighted in #1397.

__LA__ - Pattern for "Total -- " was being excluded incorrectly.

__GA__ - Name included ", \<district\>" at the end. Splits on ", " and only saves the name part. This also fixes #1360

__HI__ - Remove trailing spaces and semicolons from name

I haven't run these through and verified the output yet.