### PR TITLE
[WIP] ME: Remove trailling " of District" for vote names

### DIFF
--- a/openstates/me/bills.py
+++ b/openstates/me/bills.py
@@ -291,7 +291,9 @@ class MEBillScraper(BillScraper):
         member_cell = page.xpath("//td[text() = 'Member']")[0]
         for row in member_cell.xpath("../../tr")[1:]:
             name = row.xpath("string(td[2])")
-            # name = name.split(" of ")[0]
+            # Change from name like "HELEN of Troy" to just "HELEN"
+            if " of " in name:
+                name = name.split(" of ")[0]
 
             vtype = row.xpath("string(td[4])")
             if vtype == 'Y':


### PR DESCRIPTION
Closes #1513.  The district can be useful to disambiguate names (e.g. "JOHN of Shire" is easier to match to a known legislator than "JOHN"). But it results in failing to name match all vote names for ME. In addition, the name "JOHN" can still be disambiguated by going to the original source using the Vote source url.

Confirmed that a sample of senators are now being matched to their leg_ids correctly on import.