### PR TITLE
HI: Remove trailing "; " from vote names

### DIFF
--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -64,7 +64,8 @@ def split_specific_votes(voters):
         voters = voters.replace('Senator(s) ', '')
     elif voters.startswith('Representative(s)'):
         voters = voters.replace('Representative(s)', '')
-    return voters.split(', ')
+    # Remove trailing spaces and semicolons
+    return (v.rstrip(' ;') for v in voters.split(', '))
 
 class HIBillScraper(BillScraper):
 


### PR DESCRIPTION
This fixes the issue with Hawaii names noted in #1528. I've verified the output by searching for sample bad names using the following query:

```js
db.votes.find({"state": "hi", $or: [{"yes_votes": { $elemMatch: {"name": "Onishi; "}}}, {"other_votes": { $elemMatch: {"name": "Onishi; "}}}, {"no_votes": { $elemMatch: {"name": "Onishi; "}}}]})
```