### PR TITLE
Convert TN to pupa

### DIFF
--- a/billy_metadata/tn.py
+++ b/billy_metadata/tn.py
@@ -1,0 +1,85 @@
+import datetime
+
+# start date of each session is the first tuesday in January after new years
+
+metadata = dict(
+    name='Tennessee',
+    abbreviation='tn',
+    capitol_timezone='America/Chicago',
+    legislature_name='Tennessee General Assembly',
+    legislature_url='http://www.legislature.state.tn.us/',
+    chambers={
+        'upper': {'name': 'Senate', 'title': 'Senator'},
+        'lower': {'name': 'House', 'title': 'Representative'},
+    },
+    terms=[
+        {'name': '106', 'sessions': ['106'],
+            'start_year': 2009, 'end_year': 2010},
+        {'name': '107', 'sessions': ['107'],
+            'start_year': 2011, 'end_year': 2012},
+        {'name': '108', 'sessions': ['108'],
+            'start_year': 2013, 'end_year': 2014},
+        {'name': '109', 'sessions': ['109', '109s1', '109s2'],
+            'start_year': 2015, 'end_year': 2016},
+        {'name': '110', 'sessions': ['110'],
+            'start_year': 2017, 'end_year': 2018},
+    ],
+    session_details={
+        '110': {
+            'type': 'primary',
+            'display_name': '110th Regular Session (2017-2018)',
+            '_scraped_name': '110th General Assembly'
+        },
+        '109s2': {
+            'type': 'special',
+            'start_date': datetime.date(2016, 9, 12),
+            'end_date': datetime.date(2016, 9, 14),
+            'display_name': '109th Second Extraordinary Session (September 2016)',
+            '_scraped_name': '2nd Extraordinary Session (September 2016)'},
+        '109s1': {
+            'type': 'special',
+            'start_date': datetime.date(2016, 2, 1),
+            'end_date': datetime.date(2016, 2, 29),
+            'display_name': '109th First Extraordinary Session (February 2016)',
+            '_scraped_name': '1st Extraordinary Session (February 2015)'},
+        '109': {
+            'type': 'primary',
+            'display_name': '109th Regular Session (2015-2016)',
+            '_scraped_name': '109th General Assembly'},
+        '108': {
+            'type': 'primary',
+            'display_name': '108th Regular Session (2013-2014)',
+            '_scraped_name': '108th General Assembly'},
+        '107': {
+            'start_date': datetime.date(2011, 1, 11),
+            'end_date': datetime.date(2012, 1, 10),
+            'type': 'primary',
+            'display_name': '107th Regular Session (2011-2012)',
+            '_scraped_name': '107th General Assembly'},
+        '106': {
+            'type': 'primary',
+            'display_name': '106th Regular Session (2009-2010)',
+            '_scraped_name': '106th General Assembly'},
+    },
+    feature_flags=['events', 'influenceexplorer'],
+    _ignored_scraped_sessions=[
+        '107th General Assembly',
+        '105th General Assembly', '104th General Assembly',
+        '103rd General Assembly', '102nd General Assembly',
+        '101st General Assembly', '100th General Assembly',
+        '99th General Assembly'
+    ]
+)
+
+
+def session_list():
+    # Special sessions are available in the archive, but not in current session.
+    # Solution is to scrape special session as part of regular session
+    from billy.scrape.utils import url_xpath
+    sessions = [
+            x for x in
+            url_xpath('http://www.capitol.tn.gov/legislation/archives.html',
+            '//h2[text()="Bills and Resolutions"]/following-sibling::ul/li/text()')
+            if x.strip()
+            ]
+    return sessions

--- a/flake8.sh
+++ b/flake8.sh
@@ -24,6 +24,7 @@ python3 -m flake8 \
     openstates/or \
     openstates/pa \
     openstates/sc \
+    openstates/tn \
     openstates/va \
     openstates/sd \
     openstates/wi \

--- a/openstates/tn/__init__.py
+++ b/openstates/tn/__init__.py
@@ -1,5 +1,6 @@
 from pupa.scrape import Jurisdiction, Organization
 
+from .bills import TNBillScraper
 from .committees import TNCommitteeScraper
 from .people import TNPersonScraper
 
@@ -11,7 +12,8 @@ class Tennessee(Jurisdiction):
     url = 'http://www.capitol.tn.gov/'
     scrapers = {
         'people': TNPersonScraper,
-        'committees': TNCommitteeScraper
+        'committees': TNCommitteeScraper,
+        'bills': TNBillScraper,
     }
     parties = [
         {'name': 'Republican'},
@@ -106,3 +108,16 @@ class Tennessee(Jurisdiction):
         yield legislature
         yield upper
         yield lower
+
+    @property
+    def sessions_by_id(self):
+        """A map of sessions in legislative_sessions indexed by their `identifer`"""
+        if hasattr(self, '_sessions_by_id'):
+            return self._sessions_by_id
+
+        self._sessions_by_id = {
+            session['identifier']: session
+            for session in self.legislative_sessions
+        }
+
+        return self._sessions_by_id

--- a/openstates/tn/__init__.py
+++ b/openstates/tn/__init__.py
@@ -1,5 +1,6 @@
 from pupa.scrape import Jurisdiction, Organization
 
+from .committees import TNCommitteeScraper
 from .people import TNPersonScraper
 
 
@@ -10,6 +11,7 @@ class Tennessee(Jurisdiction):
     url = 'http://www.capitol.tn.gov/'
     scrapers = {
         'people': TNPersonScraper,
+        'committees': TNCommitteeScraper
     }
     parties = [
         {'name': 'Republican'},

--- a/openstates/tn/__init__.py
+++ b/openstates/tn/__init__.py
@@ -2,6 +2,7 @@ from pupa.scrape import Jurisdiction, Organization
 
 from .bills import TNBillScraper
 from .committees import TNCommitteeScraper
+from .events import TNEventScraper
 from .people import TNPersonScraper
 
 
@@ -11,9 +12,10 @@ class Tennessee(Jurisdiction):
     name = "Tennessee"
     url = 'http://www.capitol.tn.gov/'
     scrapers = {
-        'people': TNPersonScraper,
-        'committees': TNCommitteeScraper,
         'bills': TNBillScraper,
+        'committees': TNCommitteeScraper,
+        'events': TNEventScraper,
+        'people': TNPersonScraper,
     }
     parties = [
         {'name': 'Republican'},

--- a/openstates/tn/__init__.py
+++ b/openstates/tn/__init__.py
@@ -2,6 +2,7 @@ from pupa.scrape import Jurisdiction, Organization
 
 from .bills import TNBillScraper
 from .committees import TNCommitteeScraper
+from .common import url_xpath
 from .events import TNEventScraper
 from .people import TNPersonScraper
 
@@ -110,6 +111,19 @@ class Tennessee(Jurisdiction):
         yield legislature
         yield upper
         yield lower
+
+    def get_session_list(self):
+        # Special sessions are available in the archive, but not in current session.
+        # Solution is to scrape special session as part of regular session
+        sessions = [
+                x for x in
+                url_xpath(
+                    'http://www.capitol.tn.gov/legislation/archives.html',
+                    '//h2[text()="Bills and Resolutions"]/following-sibling::ul/li/text()'
+                )
+                if x.strip()
+        ]
+        return sessions
 
     @property
     def sessions_by_id(self):

--- a/openstates/tn/__init__.py
+++ b/openstates/tn/__init__.py
@@ -1,98 +1,106 @@
-import re
-import datetime
-from billy.utils.fulltext import pdfdata_to_text
-from .bills import TNBillScraper
-from .legislators import TNLegislatorScraper
-from .committees import TNCommitteeScraper
-from .events import TNEventScraper
+from pupa.scrape import Jurisdiction, Organization
 
-settings = dict(SCRAPELIB_TIMEOUT=600)
+from .people import TNPersonScraper
 
-#start date of each session is the first tuesday in January after new years
 
-metadata = dict(
-    name='Tennessee',
-    abbreviation='tn',
-    capitol_timezone='America/Chicago',
-    legislature_name='Tennessee General Assembly',
-    legislature_url='http://www.legislature.state.tn.us/',
-    chambers={
-        'upper': {'name': 'Senate', 'title': 'Senator'},
-        'lower': {'name': 'House', 'title': 'Representative'},
-    },
-    terms=[
-        {'name': '106', 'sessions': ['106'],
-            'start_year': 2009, 'end_year': 2010},
-        {'name': '107', 'sessions': ['107'],
-            'start_year': 2011, 'end_year': 2012},
-        {'name': '108', 'sessions': ['108'],
-            'start_year': 2013, 'end_year': 2014},
-        {'name': '109', 'sessions': ['109','109s1','109s2'],
-            'start_year': 2015, 'end_year': 2016},
-        {'name': '110', 'sessions': ['110'],
-            'start_year': 2017, 'end_year': 2018},
-    ],
-    session_details={
-        '110': {
-            'type': 'primary',
-            'display_name': '110th Regular Session (2017-2018)',
-            '_scraped_name': '110th General Assembly'
-        },
-        '109s2': {
-            'type': 'special',
-            'start_date': datetime.date(2016, 9, 12),
-            'end_date': datetime.date(2016, 9, 14),
-            'display_name': '109th Second Extraordinary Session (September 2016)',
-            '_scraped_name': '2nd Extraordinary Session (September 2016)'},
-        '109s1': {
-            'type': 'special',
-            'start_date': datetime.date(2016, 2, 1),
-            'end_date': datetime.date(2016, 2, 29),
-            'display_name': '109th First Extraordinary Session (February 2016)',
-            '_scraped_name': '1st Extraordinary Session (February 2015)'},
-        '109': {
-            'type': 'primary',
-            'display_name': '109th Regular Session (2015-2016)',
-            '_scraped_name': '109th General Assembly'},
-        '108': {
-            'type': 'primary',
-            'display_name': '108th Regular Session (2013-2014)',
-            '_scraped_name': '108th General Assembly'},
-        '107': {
-            'start_date': datetime.date(2011, 1, 11),
-            'end_date': datetime.date(2012, 1, 10),
-            'type': 'primary',
-            'display_name': '107th Regular Session (2011-2012)',
-            '_scraped_name': '107th General Assembly'},
-        '106': {
-            'type': 'primary',
-            'display_name': '106th Regular Session (2009-2010)',
-            '_scraped_name': '106th General Assembly'},
-    },
-    feature_flags=['events', 'influenceexplorer'],
-    _ignored_scraped_sessions=[
-        '107th General Assembly',
-        '105th General Assembly', '104th General Assembly',
-        '103rd General Assembly', '102nd General Assembly',
-        '101st General Assembly', '100th General Assembly',
-        '99th General Assembly'
+class Tennessee(Jurisdiction):
+    division_id = "ocd-division/country:us/state:tn"
+    classification = "government"
+    name = "Tennessee"
+    url = 'http://www.capitol.tn.gov/'
+    scrapers = {
+        'people': TNPersonScraper,
+    }
+    parties = [
+        {'name': 'Republican'},
+        {'name': 'Democratic'}
     ]
-)
+    legislative_sessions = [
+        {
+            "_scraped_name": "106th General Assembly",
+            "classification": "primary",
+            "identifier": "106",
+            "name": "106th Regular Session (2009-2010)"
+        },
+        {
+            "_scraped_name": "107th General Assembly",
+            "classification": "primary",
+            "end_date": "2012-01-10",
+            "identifier": "107",
+            "name": "107th Regular Session (2011-2012)",
+            "start_date": "2011-01-11"
+        },
+        {
+            "_scraped_name": "108th General Assembly",
+            "classification": "primary",
+            "identifier": "108",
+            "name": "108th Regular Session (2013-2014)"
+        },
+        {
+            "_scraped_name": "109th General Assembly",
+            "classification": "primary",
+            "identifier": "109",
+            "name": "109th Regular Session (2015-2016)"
+        },
+        {
+            "_scraped_name": "1st Extraordinary Session (February 2015)",
+            "classification": "special",
+            "end_date": "2016-02-29",
+            "identifier": "109s1",
+            "name": "109th First Extraordinary Session (February 2016)",
+            "start_date": "2016-02-01"
+        },
+        {
+            "_scraped_name": "2nd Extraordinary Session (September 2016)",
+            "classification": "special",
+            "end_date": "2016-09-14",
+            "identifier": "109s2",
+            "name": "109th Second Extraordinary Session (September 2016)",
+            "start_date": "2016-09-12"
+        },
+        {
+            "_scraped_name": "110th General Assembly",
+            "classification": "primary",
+            "identifier": "110",
+            "name": "110th Regular Session (2017-2018)"
+        }
+    ]
+    ignored_scraped_sessions = [
+        "107th General Assembly",
+        "105th General Assembly",
+        "104th General Assembly",
+        "103rd General Assembly",
+        "102nd General Assembly",
+        "101st General Assembly",
+        "100th General Assembly",
+        "99th General Assembly"
+    ]
 
+    def get_organizations(self):
+        legislature_name = "Tennessee General Assembly"
+        lower_chamber_name = "House"
+        lower_seats = 99
+        lower_title = "Representative"
+        upper_chamber_name = "Senate"
+        upper_seats = 33
+        upper_title = "Senator"
 
-def session_list():
-    # Special sessions are available in the archive, but not in current session.
-    # Solution is to scrape special session as part of regular session
-    from billy.scrape.utils import url_xpath
-    sessions = [
-            x for x in
-            url_xpath('http://www.capitol.tn.gov/legislation/archives.html',
-            '//h2[text()="Bills and Resolutions"]/following-sibling::ul/li/text()')
-            if x.strip()
-            ]
-    return sessions
+        legislature = Organization(name=legislature_name,
+                                   classification="legislature")
+        upper = Organization(upper_chamber_name, classification='upper',
+                             parent_id=legislature._id)
+        lower = Organization(lower_chamber_name, classification='lower',
+                             parent_id=legislature._id)
 
+        for n in range(1, upper_seats+1):
+            upper.add_post(
+                label=str(n), role=upper_title,
+                division_id='{}/sldu:{}'.format(self.division_id, n))
+        for n in range(1, lower_seats+1):
+            lower.add_post(
+                label=str(n), role=lower_title,
+                division_id='{}/sldl:{}'.format(self.division_id, n))
 
-def extract_text(doc, data):
-    return ' '.join(line for line in pdfdata_to_text(data).splitlines()
-                    if re.findall('[a-z]', line)).decode('utf8')
+        yield legislature
+        yield upper
+        yield lower

--- a/openstates/tn/bills.py
+++ b/openstates/tn/bills.py
@@ -3,8 +3,11 @@ import lxml.html
 import re
 from collections import namedtuple
 
-from billy.scrape.bills import BillScraper, Bill
-from billy.scrape.votes import Vote
+from pupa.scrape import (
+    Bill,
+    Scraper,
+    VoteEvent,
+)
 
 
 class Rule(namedtuple('Rule', 'regex types stop attrs')):
@@ -23,7 +26,7 @@ class Rule(namedtuple('Rule', 'regex types stop attrs')):
         'Create new instance of Rule(regex, types, attrs, stop)'
 
         # Types can be a string or a sequence.
-        if isinstance(types, basestring):
+        if isinstance(types, str):
             types = set([types])
         types = set(types or [])
 
@@ -35,94 +38,96 @@ class Rule(namedtuple('Rule', 'regex types stop attrs')):
 
 
 # These are regex patterns that map to action categories.
+# TODO: Check that these are up to date
 _categorizer_rules = (
 
     # Some actions are listed in the wrong chamber column.
     # Fix the chamber before moving on to the other rules.
-    Rule(r'^H\.\s', stop=False, actor='lower'),
-    Rule(r'^S\.\s', stop=False, actor='upper'),
-    Rule(r'Signed by S(\.|enate) Speaker', actor='upper'),
-    Rule(r'Signed by H(\.|ouse) Speaker', actor='lower'),
+    Rule(r'^H\.\s', stop=False, chamber='lower'),
+    Rule(r'^S\.\s', stop=False, chamber='upper'),
+    Rule(r'Signed by S(\.|enate) Speaker', chamber='upper'),
+    Rule(r'Signed by H(\.|ouse) Speaker', chamber='lower'),
+
     # Extract the vote counts to help disambiguate chambers later.
     Rule(r'Ayes\s*(?P<yes_votes>\d+),\s*Nays\s*(?P<no_votes>\d+)', stop=False),
 
     # Committees
-    Rule(r'(?i)ref\. to (?P<committees>.+?Comm\.)', 'committee:referred'),
-    Rule(r'^Failed In S\.(?P<committees>.+?Comm\.)', 'committee:failed'),
-    Rule(r'^Failed In s/c (?P<committees>.+)', 'committee:failed'),
+    Rule(r'(?i)ref\. to (?P<committees>.+?Comm\.)', 'referral-committee'),
+    Rule(r'^Failed In S\.(?P<committees>.+?Comm\.)', 'committee-failure'),
+    Rule(r'^Failed In s/c (?P<committees>.+)', 'committee-failure'),
     Rule(r'Rcvd\. from H., ref\. to S\. (?P<committees>.+)',
-         'committee:referred', actor='upper'),
+         'referral-committee', chamber='upper'),
     Rule(r'Placed on cal\. (?P<committees>.+?) for', stop=False),
     Rule(r'Taken off notice for cal in s/c (?P<committees>.+)'),
     Rule(r'to be heard in (?P<committees>.+?Comm\.)'),
     Rule(r'Action Def. in S. (?P<committees>.+?Comm.)',
-         actor='upper'),
+         chamber='upper'),
     Rule(r'(?i)Placed on S. (?P<committees>.+?Comm\.) cal. for',
-         actor='upper'),
+         chamber='upper'),
     Rule(r'(?i)Assigned to (?P<committees>.+?comm\.)'),
     Rule(r'(?i)Placed on S. (?P<committees>.+?Comm.) cal.',
-         actor='upper'),
+         chamber='upper'),
     Rule(r'(?i)Taken off Notice For cal\. in s/c.+?\sof\s(?P<committees>.+?)'),
     Rule(r'(?i)Taken off Notice For cal\. in s/c.+?\sof\s(?P<committees>.+?)'),
     Rule(r'(?i)Taken off Notice For cal\. in[: ]+(?!s/c)(?P<committees>.+)'),
-    Rule(r'(?i)Re-referred To:\s+(?P<committees>.+)', 'committee:referred'),
+    Rule(r'(?i)Re-referred To:\s+(?P<committees>.+)', 'referral-committee'),
     Rule(r'Recalled from S. (?P<committees>.+?Comm.)'),
 
     # Amendments
-    Rule(r'^Am\..+?tabled', 'amendment:tabled'),
+    Rule(r'^Am\..+?tabled', 'amendment-deferral'),
     Rule('^Am\. withdrawn\.\(Amendment \d+ \- (?P<version>\S+)',
-         'amendment:withdrawn'),
+         'amendment-withdrawal'),
     Rule(r'^Am\. reconsidered(, withdrawn)?\.\(Amendment \d \- (?P<version>.+?\))',
-         'amendment:withdrawn'),
+         'amendment-withdrawal'),
     Rule(r'adopted am\.\(Amendment \d+ of \d+ - (?P<version>\S+)\)',
-         'amendment:passed'),
-    Rule(r'refused to concur.+?in.+?am', 'amendment:failed'),
+         'amendment-passage'),
+    Rule(r'refused to concur.+?in.+?am', 'amendment-failure'),
 
     # Bill passage
-    Rule(r'^Passed H\.', 'bill:passed', actor='lower'),
-    Rule(r'^Passed S\.', 'bill:passed', actor='upper'),
-    Rule(r'^R/S Adopted', 'bill:passed'),
-    Rule(r'R/S Intro., adopted', 'bill:passed'),
-    Rule(r'R/S Concurred', 'bill:passed'),
+    Rule(r'^Passed H\.', 'passage', chamber='lower'),
+    Rule(r'^Passed S\.', 'passage', chamber='upper'),
+    Rule(r'^R/S Adopted', 'passage'),
+    Rule(r'R/S Intro., adopted', 'passage'),
+    Rule(r'R/S Concurred', 'passage'),
 
     # Veto
-    Rule(r'(?i)veto', 'governor:vetoed'),
+    Rule(r'(?i)veto', 'executive-veto'),
 
     # The existing rules for TN categorization:
-    Rule('Amendment adopted', 'amendment:passed'),
-    Rule('Amendment failed', 'amendment:failed'),
-    Rule('Amendment proposed', 'amendment:introduced'),
-    Rule('adopted am.', 'amendment:passed'),
-    Rule('Am. withdrawn', 'amendment:withdrawn'),
-    Rule('Divided committee report', 'committee:passed'),
-    Rule('Filed for intro.', ['bill:introduced', 'bill:reading:1']),
-    Rule('Reported back amended, do not pass', 'committee:passed:unfavorable'),
-    Rule('Reported back amended, do pass', 'committee:passed:favorable'),
-    Rule('Rec. For Pass.', 'committee:passed:favorable'),
-    Rule('Rec. For pass.', 'committee:passed:favorable'),
-    Rule('Reported back amended, without recommendation', 'committee:passed'),
-    Rule('Reported back, do not pass', 'committee:passed:unfavorable'),
-    Rule('w/ recommend', 'committee:passed:favorable'),
-    Rule('Ref. to', 'committee:referred'),
-    Rule('ref. to', 'committee:referred'),
-    Rule('Assigned to', 'committee:referred'),
-    Rule('Received from House', 'bill:introduced'),
-    Rule('Received from Senate', 'bill:introduced'),
-    Rule('Adopted, ', ['bill:passed']),
-    Rule('Concurred, ', ['bill:passed']),
-    Rule('Passed H., ', ['bill:passed']),
-    Rule('Passed S., ', ['bill:passed']),
-    Rule('Second reading, adopted', ['bill:passed', 'bill:reading:2']),
-    Rule('Second reading, failed', ['bill:failed', 'bill:reading:2']),
-    Rule('Second reading, passed', ['bill:passed', 'bill:reading:2']),
-    Rule('Transmitted to Gov. for action.', 'governor:received'),
-    Rule('Transmitted to Governor for his action.', 'governor:received'),
-    Rule('Signed by Governor, but item veto', 'governor:vetoed:line-item'),
-    Rule('Signed by Governor', 'governor:signed'),
-    Rule('Withdrawn', 'bill:withdrawn'),
-    Rule('tabled', 'amendment:tabled'),
-    Rule('widthrawn', 'amendment:withdrawn'),
-    Rule(r'Intro', 'bill:introduced'),
+    Rule('Amendment adopted', 'amendment-passage'),
+    Rule('Amendment failed', 'amendment-failure'),
+    Rule('Amendment proposed', 'amendment-introduction'),
+    Rule('adopted am.', 'amendment-passage'),
+    Rule('Am. withdrawn', 'amendment-withdrawal'),
+    Rule('Divided committee report', 'committee-passage'),
+    Rule('Filed for intro.', ['introduction', 'reading-1']),
+    Rule('Reported back amended, do not pass', 'committee-passage-unfavorable'),
+    Rule('Reported back amended, do pass', 'committee-passage-favorable'),
+    Rule('Rec. For Pass.', 'committee-passage-favorable'),
+    Rule('Rec. For pass.', 'committee-passage-favorable'),
+    Rule('Reported back amended, without recommendation', 'committee-passage'),
+    Rule('Reported back, do not pass', 'committee-passage-unfavorable'),
+    Rule('w/ recommend', 'committee-passage-favorable'),
+    Rule('Ref. to', 'referral-committee'),
+    Rule('ref. to', 'referral-committee'),
+    Rule('Assigned to', 'referral-committee'),
+    Rule('Received from House', 'introduction'),
+    Rule('Received from Senate', 'introduction'),
+    Rule('Adopted, ', ['passage']),
+    Rule('Concurred, ', ['passage']),
+    Rule('Passed H., ', ['passage']),
+    Rule('Passed S., ', ['passage']),
+    Rule('Second reading, adopted', ['passage', 'reading-2']),
+    Rule('Second reading, failed', ['failure', 'reading-2']),
+    Rule('Second reading, passed', ['passage', 'reading-2']),
+    Rule('Transmitted to Gov. for action.', 'executive-receipt'),
+    Rule('Transmitted to Governor for his action.', 'executive-receipt'),
+    Rule('Signed by Governor, but item veto', 'executive-veto:line-item'),
+    Rule('Signed by Governor', 'executive-signature'),
+    Rule('Withdrawn', 'withdrawal'),
+    Rule('tabled', 'amendment-deferral'),
+    Rule('widthrawn', 'amendment-withdrawal'),
+    Rule(r'Intro', 'introduction'),
 )
 
 
@@ -166,33 +171,50 @@ def actions_from_table(bill, actions_table):
         tds = ar.xpath('td')
         action_taken = tds[0].text
         strptime = datetime.datetime.strptime
-        action_date = strptime(tds[1].text.strip(), '%m/%d/%Y')
+        action_date = strptime(tds[1].text.strip(), '%m/%d/%Y').date()
         action_types, attrs = categorize_action(action_taken)
         # Overwrite any presumtive fields that are inaccurate, usually chamber.
         action = dict(action=action_taken, date=action_date,
-                      type=action_types, actor=chamber)
+                      classification=action_types, chamber=chamber)
         action.update(**attrs)
 
         # Finally, if a vote tally is given, switch the chamber.
         if set(['yes_votes', 'no_votes']) & set(attrs):
             total_votes = int(attrs['yes_votes']) + int(attrs['no_votes'])
+            # TODO: Should this be 33, or does it include other entities in the vote?
             if total_votes > 35:
-                action['actor'] = 'lower'
+                action['chamber'] = 'lower'
             if total_votes <= 35:
-                action['actor'] = 'upper'
+                action['chamber'] = 'upper'
 
-        bill.add_action(**action)
+        # TODO: Add `committees` scraped from the action using related_entities
+        # Can we also make use of `version`?
+        bill.add_action(
+            action['action'],
+            action['date'],
+            chamber=action['chamber'],
+            classification=action['classification'],
+        )
 
 
-class TNBillScraper(BillScraper):
-    jurisdiction = 'tn'
+class TNBillScraper(Scraper):
 
-    def scrape(self, term, chambers):
+    def scrape(self, session=None, chamber=None):
+        if not session:
+            session = self.latest_session()
+            self.info('no session specified, using %s', session)
+
+        chambers = [chamber] if chamber else ['upper', 'lower']
+        for chamber in chambers:
+            yield from self.scrape_chamber(chamber, session)
+
+    def scrape_chamber(self, chamber, session):
+        session_details = self.jurisdiction.sessions_by_id[session]
 
         # The index page gives us links to the paginated bill pages
         if self.metadata['session_details'][term]['type'] == 'special':
             index_page = 'http://wapp.capitol.tn.gov/apps/indexes/SPSession1.aspx'
-            xpath = '//h4[text()="%s"]/following-sibling::table[1]/tbody/tr/td/a' % self.metadata['session_details'][term]['_scraped_name']
+            xpath = '//h4[text()="%s"]/following-sibling::table[1]/tbody/tr/td/a' % session_details['_scraped_name']
         else:
             index_page = 'http://wapp.capitol.tn.gov/apps/indexes/'
             xpath = '//td[contains(@class,"webindex")]/a'
@@ -215,9 +237,11 @@ class TNBillScraper(BillScraper):
                 '//h1[text()="Legislation"]/following-sibling::div/'
                 'div/div/div/label//a/@href'
                 ):
-                self.scrape_bill(term, bill_link)
+                bill = self.scrape_bill(session, bill_link)
+                if bill:
+                    yield bill
 
-    def scrape_bill(self, term, bill_url):
+    def scrape_bill(self, session, bill_url):
         page = self.get(bill_url).text
         page = lxml.html.fromstring(page)
         page.make_links_absolute(bill_url)
@@ -247,7 +271,6 @@ class TNBillScraper(BillScraper):
         elif 'R' in bill_id:
             bill_type = 'resolution'
 
-
         primary_chamber = 'lower' if 'H' in bill_id else 'upper'
         # secondary_chamber = 'upper' if primary_chamber == 'lower' else 'lower'
 
@@ -262,38 +285,51 @@ class TNBillScraper(BillScraper):
         subjects = [s.strip() for s in title[:subject_pos - 1].split(',')]
         subjects = filter(None, subjects)
 
-        bill = Bill(term, primary_chamber, bill_id, title, type=bill_type,
-                    subjects=subjects)
+        bill = Bill(
+            bill_id,
+            legislative_session=session,
+            chamber=primary_chamber,
+            title=title,
+            classification=bill_type,
+        )
+        for subject in subjects:
+            bill.add_subject(subject)
+
         if secondary_bill_id:
-            bill['alternate_bill_ids'] = [secondary_bill_id]
+            bill.add_identifier(secondary_bill_id)
+
         bill.add_source(bill_url)
 
         # Primary Sponsor
         sponsor = page.xpath("//span[@id='lblBillPrimeSponsor']")[0].text_content().split("by")[-1]
         sponsor = sponsor.replace('*', '').strip()
         if sponsor:
-            bill.add_sponsor('primary', sponsor)
+            bill.add_sponsorship(
+                sponsor,
+                classification='primary',
+                entity_type='person',
+                primary=True,
+            )
 
         # bill text
         btext = page.xpath("//span[@id='lblBillNumber']/a")[0]
-        bill.add_version('Current Version', btext.get('href'),
-                         mimetype='application/pdf')
+        bill.add_version_link('Current Version', btext.get('href'),
+                              media_type='application/pdf')
 
         # documents
         summary = page.xpath('//a[contains(@href, "BillSummaryArchive")]')
         if summary:
-            bill.add_document('Summary', summary[0].get('href'))
+            bill.add_document_link('Summary', summary[0].get('href'))
         fiscal = page.xpath('//span[@id="lblFiscalNote"]//a')
         if fiscal:
-            bill.add_document('Fiscal Note', fiscal[0].get('href'))
+            bill.add_document_link('Fiscal Note', fiscal[0].get('href'))
         amendments = page.xpath('//a[contains(@href, "/Amend/")]')
         for amendment in amendments:
-            bill.add_document('Amendment ' + amendment.text,
-                              amendment.get('href'))
+            bill.add_document_link('Amendment ' + amendment.text, amendment.get('href'))
         # amendment notes in image with alt text describing doc inside <a>
         amend_fns = page.xpath('//img[contains(@alt, "Fiscal Memo")]')
         for afn in amend_fns:
-            bill.add_document(afn.get('alt'), afn.getparent().get('href'))
+            bill.add_document_link(afn.get('alt'), afn.getparent().get('href'), on_duplicate='ignore')
 
         # actions
         atable = page.xpath("//table[@id='gvBillActionHistory']")[0]
@@ -306,19 +342,24 @@ class TNBillScraper(BillScraper):
             secondary_sponsor = secondary_sponsor.replace('*', '').replace(')', '').strip()
             # Skip black-name sponsors.
             if secondary_sponsor:
-                bill.add_sponsor('primary', secondary_sponsor)
+                bill.add_sponsorship(
+                    secondary_sponsor,
+                    classification='primary',
+                    entity_type='person',
+                    primary=True,
+                )
 
             # secondary actions
             cotable = page.xpath("//table[@id='gvCoActionHistory']")[0]
             actions_from_table(bill, cotable)
 
         # votes
-        bill = self.scrape_votes(bill, page, bill_url)
+        yield from self.scrape_vote_events(bill, page, bill_url)
 
-        bill['actions'].sort(key=lambda a: a['date'])
-        self.save_bill(bill)
+        bill.actions.sort(key=lambda a: a['date'])
+        yield bill
 
-    def scrape_votes(self, bill, page, link):
+    def scrape_vote_events(self, bill, page, link):
         chamber_labels = (
             ('lower', 'lblHouseVoteData'),
             ('upper', 'lblSenateVoteData')
@@ -327,12 +368,9 @@ class TNBillScraper(BillScraper):
             raw_vote_data = page.xpath("//*[@id='{}']".format(element_id))[0].text_content()
             votes = self.scrape_votes_for_chamber(chamber, raw_vote_data, bill, link)
             for vote in votes:
-                bill.add_vote(vote)
-
-        return bill
+                yield vote
 
     def scrape_votes_for_chamber(self, chamber, vote_data, bill, link):
-        votes = []
         raw_vote_data = re.split('\w+? by [\w ]+?\s+-', vote_data.strip())[1:]
         for raw_vote in raw_vote_data:
             raw_vote = raw_vote.split(u'\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0')
@@ -350,13 +388,13 @@ class TNBillScraper(BillScraper):
             vote_regex = re.compile('\d+$')
             aye_regex = re.compile('^.+voting aye were: (.+) -')
             no_regex = re.compile('^.+voting no were: (.+) -')
-            other_regex = re.compile('^.+present and not voting were: (.+) -')
+            not_voting_regex = re.compile('^.+present and not voting were: (.+) -')
             yes_count = 0
             no_count = 0
-            other_count = 0
+            not_voting_count = 0
             ayes = []
             nos = []
-            others = []
+            not_voting = []
 
             for v in raw_vote[1:]:
                 v = v.strip()
@@ -365,16 +403,25 @@ class TNBillScraper(BillScraper):
                 elif v.startswith('Noes...') and vote_regex.search(v):
                     no_count = int(vote_regex.search(v).group())
                 elif v.startswith('Present and not voting...') and vote_regex.search(v):
-                    other_count += int(vote_regex.search(v).group())
+                    not_voting_count += int(vote_regex.search(v).group())
                 elif aye_regex.search(v):
                     ayes = aye_regex.search(v).groups()[0].split(', ')
                 elif no_regex.search(v):
                     nos = no_regex.search(v).groups()[0].split(', ')
-                elif other_regex.search(v):
-                    others += other_regex.search(v).groups()[0].split(', ')
+                elif not_voting_regex.search(v):
+                    not_voting += not_voting_regex.search(v).groups()[0].split(', ')
 
-            vote = Vote(chamber, vote_date, motion, passed, yes_count,
-                        no_count, other_count)
+            vote = VoteEvent(
+                motion_text=motion.strip(),
+                start_date=vote_date.strftime('%Y-%m-%d') if vote_date else None,
+                classification='passage',
+                result='pass' if passed else 'fail',
+                chamber=chamber,
+                bill=bill,
+            )
+            vote.set_count('yes', yes_count)
+            vote.set_count('no', no_count)
+            vote.set_count('not voting', not_voting_count)
             vote.add_source(link)
 
             seen = set()
@@ -388,12 +435,10 @@ class TNBillScraper(BillScraper):
                     continue
                 vote.no(n)
                 seen.add(n)
-            for o in others:
-                if o in seen:
+            for n in not_voting:
+                if n in seen:
                     continue
-                vote.other(o)
-                seen.add(o)
+                vote.vote('not voting', n)
+                seen.add(n)
 
-            votes.append(vote)
-
-        return votes
+            yield vote

--- a/openstates/tn/committees.py
+++ b/openstates/tn/committees.py
@@ -90,7 +90,8 @@ class TNCommitteeScraper(Scraper):
 
         is_subcommittee = bool(page.xpath('//li/a[text()="Committee"]'))
         if is_subcommittee:
-            # All TN subcommittees are just the name of the parent committee with " Subcommittee" at the end
+            # All TN subcommittees are just the name of the parent committee with " Subcommittee"
+            # at the end
             parent_committee_name = re.sub(r'\s*Subcommittee\s*', '', committee_name)
             com = Organization(
                     committee_name,
@@ -105,13 +106,9 @@ class TNCommitteeScraper(Scraper):
             )
 
         OFFICER_SEARCH = '//h2[contains(text(), "Committee Officers")]/' \
-                     'following-sibling::div/ul/li/a'
+                         'following-sibling::div/ul/li/a'
         MEMBER_SEARCH = '//h2[contains(text(), "Committee Members")]/' \
-                     'following-sibling::div/ul/li/a'
-        HOUSE_SEARCH = '//h2[contains(text(), "House Members")]/' \
-                     'following-sibling::div/ul/li/a'
-        SENATE_SEARCH = '//h2[contains(text(), "House Members")]/' \
-                     'following-sibling::div/ul/li/a'
+                        'following-sibling::div/ul/li/a'
         for a in (page.xpath(OFFICER_SEARCH) + page.xpath(MEMBER_SEARCH)):
 
             member_name = ' '.join([
@@ -131,7 +128,7 @@ class TNCommitteeScraper(Scraper):
         com.add_source(link)
         return com
 
-    #Scrapes joint committees
+    # Scrapes joint committees
     def scrape_joint_committees(self):
         main_url = 'http://www.capitol.tn.gov/joint/'
 
@@ -146,7 +143,7 @@ class TNCommitteeScraper(Scraper):
             if com:
                 yield com
 
-    #Scrapes the individual joint committee - most of it is special case
+    # Scrapes the individual joint committee - most of it is special case
     def scrape_joint_committee(self, committee_name, url):
         if 'state.tn.us' in url:
             com = Organization(
@@ -162,7 +159,9 @@ class TNCommitteeScraper(Scraper):
 
             page = lxml.html.fromstring(page)
 
-            for el in page.xpath("//div[@class='Blurb']/table//tr[2 <= position() and  position() < 10]/td[1]"):
+            for el in page.xpath(
+                "//div[@class='Blurb']/table//tr[2 <= position() and  position() < 10]/td[1]"
+            ):
                 if el.xpath('text()') == ['Vacant']:
                     continue
 
@@ -197,9 +196,9 @@ class TNCommitteeScraper(Scraper):
                 chamber_page = lxml.html.fromstring(chamber_page)
 
                 OFFICER_SEARCH = '//h2[contains(text(), "Committee Officers")]/' \
-                             'following-sibling::div/ul/li/a'
+                                 'following-sibling::div/ul/li/a'
                 MEMBER_SEARCH = '//h2[contains(text(), "Committee Members")]/' \
-                             'following-sibling::div/ul/li/a'
+                                'following-sibling::div/ul/li/a'
                 for a in (
                         chamber_page.xpath(OFFICER_SEARCH) +
                         chamber_page.xpath(MEMBER_SEARCH)

--- a/openstates/tn/common.py
+++ b/openstates/tn/common.py
@@ -1,0 +1,7 @@
+import requests
+import lxml.html
+
+
+def url_xpath(url, path):
+    doc = lxml.html.fromstring(requests.get(url).text)
+    return doc.xpath(path)

--- a/openstates/tn/events.py
+++ b/openstates/tn/events.py
@@ -121,14 +121,14 @@ class TNEventScraper(Scraper, LXMLMixin):
                     when = self._utc.localize(when)
 
                 event = Event(
-                    description,
-                    when,
-                    when.tzname(),
-                    location,
+                    name=description,
+                    start_time=when,
+                    timezone=when.tzname(),
+                    location_name=location,
                     description=description,
                 )
                 # The description is a committee name
-                event.add_committee(description)
+                event.add_committee(name=description)
                 event.add_source(cal_weekly_events)
 
                 agenda = metainf['agenda'].xpath(".//a")

--- a/openstates/tn/events.py
+++ b/openstates/tn/events.py
@@ -10,10 +10,11 @@ import pytz
 
 cal_weekly_events = "http://wapp.capitol.tn.gov/apps/schedule/WeeklyView.aspx"
 cal_chamber_text = {
-    "upper" : "Senate",
-    "lower" : "House",
-    "other" : "Joint"
+    "upper": "Senate",
+    "lower": "House",
+    "other": "Joint"
 }
+
 
 class TNEventScraper(Scraper, LXMLMixin):
     _tz = pytz.timezone('US/Central')
@@ -92,7 +93,7 @@ class TNEventScraper(Scraper, LXMLMixin):
 
                 time = metainf['time'].text_content()
                 datetime_string = "%s %s" % \
-                        (date.strip(' \r\n'), time.strip(' \r\n'))
+                                  (date.strip(' \r\n'), time.strip(' \r\n'))
                 location = metainf['location'].text_content()
                 description = metainf['type'].text_content()
                 dtfmt = "%A, %B %d, %Y %I:%M %p"

--- a/openstates/tn/events.py
+++ b/openstates/tn/events.py
@@ -1,10 +1,11 @@
 import datetime as dt
 
-from billy.scrape import NoDataForPeriod
-from billy.scrape.events import Event, EventScraper
+from pupa.scrape import (
+    Event,
+    Scraper,
+)
 from openstates.utils import LXMLMixin
 
-import lxml.html
 import pytz
 
 cal_weekly_events = "http://wapp.capitol.tn.gov/apps/schedule/WeeklyView.aspx"
@@ -14,10 +15,9 @@ cal_chamber_text = {
     "other" : "Joint"
 }
 
-class TNEventScraper(EventScraper, LXMLMixin):
-    jurisdiction = 'tn'
-
-    _tz = pytz.timezone('US/Eastern')
+class TNEventScraper(Scraper, LXMLMixin):
+    _tz = pytz.timezone('US/Central')
+    _utc = pytz.timezone('UTC')
 
     def url_xpath(self, url, xpath):
         page = self.lxmlize(url)
@@ -40,13 +40,10 @@ class TNEventScraper(EventScraper, LXMLMixin):
             tds = tr.xpath("./*")
             billinf = tds[0].attrib['id']  # TN uses bill_ids as the id
             descr = tr.xpath("./td//p")[-1].text_content()
-            event.add_related_bill(
-                billinf,
-                description=descr,
-                type="consideration"
-            )
+            agenda_item = event.add_agenda_item(descr)
+            agenda_item.add_bill(billinf, id=billinf)
         event.add_source(url)
-        event.add_document(url=url, name="Agenda", type="agenda")
+        event.add_document("Agenda", url)
         return event
 
     def _add_agenda_list(self, url, event):
@@ -60,12 +57,17 @@ class TNEventScraper(EventScraper, LXMLMixin):
     def add_agenda(self, url, name, event):
         if "CalendarMain" in url:
             return self._add_agenda_main(url, event)
-        if "scheduledocs" in url:
-            return event.add_document(name=name, url=url, type="agenda")
-        return event.add_document(name=name, url=url, type="other")
+        return event.add_document(name, url)
 
-    def scrape(self, chamber, session):
-        chmbr = cal_chamber_text[chamber]
+    def scrape(self, chamber=None):
+        if chamber:
+            yield from self.scrape_chamber(chamber)
+        else:
+            yield from self.scrape_chamber()
+
+    def scrape_chamber(self, chamber=None):
+        # If chamber is None, don't exclude any events from the results based on chamber
+        chmbr = cal_chamber_text.get(chamber)
         tables = self.url_xpath(cal_weekly_events,
                                 "//table[@class='date-table']")
         for table in tables:
@@ -84,8 +86,8 @@ class TNEventScraper(EventScraper, LXMLMixin):
                 for el in range(0, len(order)):
                     metainf[order[el]] = tds[el]
 
-                if metainf['chamber'].text_content() == chmbr:
-                    self.log("Skipping event based on chamber.")
+                if chmbr and metainf['chamber'].text_content() != chmbr:
+                    self.info("Skipping event based on chamber.")
                     continue
 
                 time = metainf['time'].text_content()
@@ -110,15 +112,22 @@ class TNEventScraper(EventScraper, LXMLMixin):
                         continue
 
                     datetime_string = datetime_string.strip()
-                    
+
                     try:
                         when = dt.datetime.strptime(datetime_string, dtfmt)
                     except ValueError:
                         when = dt.datetime.strptime(datetime_string, dtfmt_no_time)
+                    when = self._utc.localize(when)
 
-                event = Event(session, when, 'committee:meeting',
-                              description, location=location)
-                event.add_participant("host", description, 'committee', chamber=chamber)
+                event = Event(
+                    description,
+                    when,
+                    when.tzname(),
+                    location,
+                    description=description,
+                )
+                # The description is a committee name
+                event.add_committee(description)
                 event.add_source(cal_weekly_events)
 
                 agenda = metainf['agenda'].xpath(".//a")
@@ -130,4 +139,4 @@ class TNEventScraper(EventScraper, LXMLMixin):
                         agenda_url = doc.attrib['href']
                         self.add_agenda(
                             agenda_url, doc.text_content(), event)
-                self.save_event(event)
+                yield event

--- a/openstates/tn/people.py
+++ b/openstates/tn/people.py
@@ -22,7 +22,7 @@ class TNPersonScraper(Scraper):
                    'CCR': 'Carter County Republican',
                    'I': 'Independent'}
 
-        #testing for chamber
+        # testing for chamber
         if chamber == 'upper':
             url_chamber_name = 'senate'
             abbr = 's'
@@ -50,9 +50,9 @@ class TNPersonScraper(Scraper):
             address = row.xpath('td[6]')[0].text_content()
             # 301 6th Avenue North Suite
             address = address.replace('LP',
-                              'Legislative Plaza\nNashville, TN 37243')
+                                      'Legislative Plaza\nNashville, TN 37243')
             address = address.replace('WMB',
-                              'War Memorial Building\nNashville, TN 37243')
+                                      'War Memorial Building\nNashville, TN 37243')
             address = '301 6th Avenue North\nSuite ' + address
             phone = [
                     x.strip() for x in
@@ -61,11 +61,11 @@ class TNPersonScraper(Scraper):
                     ][0]
 
             email = html.parser.HTMLParser().unescape(
-                    row.xpath('td[1]/a/@href')[0][len("mailto:"): ])
+                    row.xpath('td[1]/a/@href')[0][len("mailto:"):])
             member_url = (root_url + url_chamber_name + '/members/' + abbr +
-                district + '.html')
+                          district + '.html')
             member_photo_url = (root_url + url_chamber_name +
-                '/members/images/' + abbr + district + '.jpg')
+                                '/members/images/' + abbr + district + '.jpg')
 
             try:
                 member_page = self.get(member_url, allow_redirects=False).text

--- a/openstates/tn/people.py
+++ b/openstates/tn/people.py
@@ -1,15 +1,22 @@
-import HTMLParser
+import html.parser
 
-from billy.scrape.legislators import LegislatorScraper, Legislator
 import lxml.html
+from pupa.scrape import (
+    Person,
+    Scraper,
+)
 from scrapelib import HTTPError
-from openstates.utils import LXMLMixin
 
-class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
-    jurisdiction = 'tn'
 
-    def scrape(self, chamber, term):
-        self.validate_term(term, latest_only=False)
+class TNPersonScraper(Scraper):
+    def scrape(self, chamber=None):
+        if chamber:
+            yield from self.scrape_chamber(chamber)
+        else:
+            yield from self.scrape_chamber('upper')
+            yield from self.scrape_chamber('lower')
+
+    def scrape_chamber(self, chamber):
         root_url = 'http://www.capitol.tn.gov/'
         parties = {'D': 'Democratic', 'R': 'Republican',
                    'CCR': 'Carter County Republican',
@@ -22,13 +29,9 @@ class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
         else:
             url_chamber_name = 'house'
             abbr = 'h'
-        if term != self.metadata["terms"][-1]["sessions"][0]:
-            chamber_url = root_url + url_chamber_name
-            chamber_url += '/archives/' + term + 'GA/Members/index.html'
-        else:
-            chamber_url = root_url + url_chamber_name + '/members/'
-
-        page = self.lxmlize(chamber_url)
+        chamber_url = root_url + url_chamber_name + '/members/'
+        page_html = self.get(chamber_url).text
+        page = lxml.html.fromstring(page_html)
 
         for row in page.xpath("//tr"):
 
@@ -57,7 +60,7 @@ class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
                     if x.strip()
                     ][0]
 
-            email = HTMLParser.HTMLParser().unescape(
+            email = html.parser.HTMLParser().unescape(
                     row.xpath('td[1]/a/@href')[0][len("mailto:"): ])
             member_url = (root_url + url_chamber_name + '/members/' + abbr +
                 district + '.html')
@@ -87,15 +90,22 @@ class TNLegislatorScraper(LegislatorScraper, LXMLMixin):
             name = name.replace('Representative ', '')
             name = name.replace('Senator ', '')
 
-            leg = Legislator(term, chamber, district, name.strip(),
-                             party=party, url=member_url,
-                             photo_url=member_photo_url)
-            leg.add_source(chamber_url)
-            leg.add_source(member_url)
+            person = Person(
+                name=name.strip(),
+                image=member_photo_url,
+                primary_org=chamber,
+                district=district,
+                party=party,
+            )
+            person.add_link(member_url)
+            person.add_source(chamber_url)
+            person.add_source(member_url)
 
             # TODO: add district address from this page
-
-            leg.add_office('capitol', 'Nashville Address',
-                           address=address, phone=phone, email=email)
-
-            self.save_legislator(leg)
+            person.add_contact_detail(type='address', value=address,
+                                      note='Capitol Office')
+            person.add_contact_detail(type='email', value=email,
+                                      note='Capitol Office')
+            person.add_contact_detail(type='voice', value=phone,
+                                      note='Capitol Office')
+            yield person

--- a/openstates/tn/people.py
+++ b/openstates/tn/people.py
@@ -54,6 +54,8 @@ class TNPersonScraper(Scraper):
             address = address.replace('WMB',
                                       'War Memorial Building\nNashville, TN 37243')
             address = '301 6th Avenue North\nSuite ' + address
+            address = address.strip()
+
             phone = [
                     x.strip() for x in
                     row.xpath('td[7]//text()')


### PR DESCRIPTION
All conversions followed the generic migration plan outlined [in the pupa conversion docs](http://docs.openstates.org/en/latest/contributing/pupa-conversion.html), except where otherwise noted.

### Bills
* replaces `HTMLParser` with it's Python3 equivalent `html.parser` (used to unescape the email addresses, maybe unnecssarily but leaving it for now)
* replaces calls to `self.lxmlize` with
```python
html = self.get(url)
page = lxml.html.fromstring(html)
```

### Committees
Only generic conversion steps

### Bills and Votes
* ignores duplicate fiscal notes for house and senate - see the Amendments section for [this bill]( http://wapp.capitol.tn.gov/apps/BillInfo/default.aspx?BillNumber=HB0018&GA=110) for for an example.
* updates "other" votes to be "not voting", a more accurate reflection of the votes being cast

### Events
* Use `add_agenda_item` and then `EventAgendaItem` methods to recreate `add_bill` on old event scraper
* Pupa requires fully qualified timezone for when, but setting timezone to correct Central resulted in bad dates in Mongo. Passing to `Event` with UTC tzinfo, but passing correct timezone to `timezone` argument results in correct dates.
* Changed timezone from "US/Eastern" to "US/Central".
* Scraper was skipping events if the event's chamber _matched_ the `chamber` variable. I think this was a mistake and should be the opposite, (skips if doesn't match), so switched.

TODO:
- [x] legislators.py -> people.py
- [x] bills.py
- [x] events.py
- [x] committees.py