### PR TITLE
Fix lint in converted jurisdiction.

### DIFF
--- a/scripts/convert_metadata.py
+++ b/scripts/convert_metadata.py
@@ -77,11 +77,11 @@ class {classname}(Jurisdiction):
         lower = Organization(lower_chamber_name, classification='lower',
                              parent_id=legislature._id)
 
-        for n in range(1, upper_seats+1):
+        for n in range(1, upper_seats + 1):
             upper.add_post(
                 label=str(n), role=upper_title,
                 division_id='{{}}/sldu:{{}}'.format(self.division_id, n))
-        for n in range(1, lower_seats+1):
+        for n in range(1, lower_seats + 1):
             lower.add_post(
                 label=str(n), role=lower_title,
                 division_id='{{}}/sldl:{{}}'.format(self.division_id, n))


### PR DESCRIPTION
Fixes `E226 missing whitespace around arithmetic operator` in generated jurisdiction classes.