### PR TITLE
CA: Skip votes with no metadata

### DIFF
--- a/openstates/ca/bills.py
+++ b/openstates/ca/bills.py
@@ -536,6 +536,9 @@ class CABillScraper(BillScraper):
                 else:
                     result = False
 
+                if not vote.location:
+                    continue
+                    
                 full_loc = vote.location.description
                 first_part = full_loc.split(' ')[0].lower()
                 if first_part in ['asm', 'assembly']:


### PR DESCRIPTION
CA put a vote into the mysql database missing key information, so skip it so the scraper doesn't choke.