### PR TITLE
NH: Fix vote names scraper

### DIFF
--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -278,14 +278,14 @@ class NHBillScraper(BillScraper):
                 votes[body+vote_num] = vote
                 self.bills_by_id[bill_id].add_vote(vote)
 
-        for line in  self.get('http://gencourt.state.nh.us/dynamicdatafiles/RollCallHistory.txt').content:
+        for line in  self.get('http://gencourt.state.nh.us/dynamicdatafiles/RollCallHistory.txt').content.splitlines():
             if len(line) < 2:
                 continue
 
             # 2016|H|2|330795||Yea|
-            # 2012    | H   | 2    | 330795  | HB309  | Yea |1/4/2012 8:27:03 PM
-            session_yr, body, v_num, employee, bill_id, vote \
-                    = line.split('|')
+            # 2012    | H   | 2    | 330795  | 964 |  HB309  | Yea | 1/4/2012 8:27:03 PM
+            session_yr, body, v_num, _, employee, bill_id, vote, date = \
+                line.split('|')
 
             if not bill_id:
                 continue


### PR DESCRIPTION
Fixes two issues with the NH voter name scrape.

* Similar to an earlier fix for the vote counts, this adds `splitlines()` to the file so that it is processed line by line instead of character by character.
* In addition, this handles an extra two columns being returned when splitting each line.

Confirmed that votes were not being saved with the bug in the voter name scrape, and they are with the fix. This fixes the underlying cause of #1563.