### PR TITLE
CO: Fix chamber-less joint bill actions

### DIFF
--- a/openstates/co/bills.py
+++ b/openstates/co/bills.py
@@ -169,8 +169,13 @@ class COBillScraper(BillScraper, LXMLMixin):
             action_date = action.xpath('td[1]/text()')[0]
             action_date = dt.datetime.strptime(action_date, '%m/%d/%Y')
 
-            action_chamber = action.xpath('td[2]/text()')[0]
-            action_actor = chamber_map[action_chamber]
+            # If an action has no chamber, it's joint
+            # e.g. http://leg.colorado.gov/bills/sb17-100 
+            if action.xpath('td[2]/text()'):
+                action_chamber = action.xpath('td[2]/text()')[0]
+                action_actor = chamber_map[action_chamber]
+            else:
+                action_actor = 'joint'
 
             action_name = action.xpath('td[3]/text()')[0]
 


### PR DESCRIPTION
CO Added some new actions with no chamber marked, which broke the bill scraper. All the current ones without chamber are joint, so adding that to the logic.