### PR TITLE
AZ: Add transmit to actions, additional bill version formats

### DIFF
--- a/openstates/az/bills.py
+++ b/openstates/az/bills.py
@@ -20,6 +20,8 @@ class AZBillScraper(BillScraper):
     """
     jurisdiction = 'az'
     chamber_map = {'lower':'H', 'upper':'S'}
+    chamber_map_rev = {'H':'upper', 'S':'lower', 'G':'executive', 'SS':'executive'}
+    chamber_map_rev_eng = {'H':'House', 'S':'Senate', 'G':'Governor', 'SS':'Secretary of State'}
 
     def get_session_id(self, session):
         """
@@ -69,11 +71,20 @@ class AZBillScraper(BillScraper):
         page = json.loads(self.get(versions_url).content)
         if page and 'Documents' in page[0]:
             for doc in page[0]['Documents']:
-                bill.add_version(
-                    name=doc['DocumentName'],
-                    url=doc['HtmlPath'],
-                    mimetype='text/html'
-                )
+                if doc['HtmlPath']:
+                    bill.add_version(
+                        name=doc['DocumentName'],
+                        url=doc['HtmlPath'],
+                        mimetype='text/html'
+                    )
+                elif doc['PdfPath']:
+                    bill.add_version(
+                        name=doc['DocumentName'],
+                        url=doc['PdfPath'],
+                        mimetype='application/pdf'
+                    )
+                else:
+                    self.warning("No PDF or HTML version found for %s" % doc['DocumentName'])
 
     def scrape_sponsors(self, bill, internal_id):
         # Careful, this sends XML to a browser but JSON to machines
@@ -118,7 +129,6 @@ class AZBillScraper(BillScraper):
         """
         for action in action_utils.action_map:
             if page[action] and action_utils.action_map[action]['name'] != '':
-                print(page[action])
                 try:
                     action_date = datetime.datetime.strptime(page[action], '%Y-%m-%dT%H:%M:%S')
                     bill.add_action(
@@ -129,6 +139,51 @@ class AZBillScraper(BillScraper):
                     )
                 except ValueError:
                     self.warning("Invalid Action Time {} for {}".format(page[action], action))
+
+        # Governor Signs and Vetos get different treatment
+        if page['GovernorAction'] == 'Signed':
+            action_date = datetime.datetime.strptime(page['GovernorActionDate'],
+                                                     '%Y-%m-%dT%H:%M:%S')
+            bill.add_action(
+                actor='executive',
+                action='Signed by Governor',
+                date=action_date,
+                type='governor:signed'
+            )
+
+        if page['GovernorAction'] == 'Vetoed':
+            action_date = datetime.datetime.strptime(page['GovernorActionDate'],
+                                                     '%Y-%m-%dT%H:%M:%S')
+            bill.add_action(
+                actor='executive',
+                action='Vetoed by Governor',
+                date=action_date,
+                type='governor:vetoed'
+            )
+
+        # Transmit to (X) has its own data structure as well
+        for transmit in page['BodyTransmittedTo']:
+            action_date = datetime.datetime.strptime(transmit['TransmitDate'],
+                                                     '%Y-%m-%dT%H:%M:%S')
+            # upper, lower, executive
+            action_actor = self.chamber_map_rev[transmit['LegislativeBody']]
+            # house, senate, governor
+            body_text = self.chamber_map_rev_eng[transmit['LegislativeBody']]
+
+            action_text = 'Transmit to {}'.format(body_text)
+
+            if action_actor == 'executive':
+                action_type = 'governor:received'
+            else:
+                action_type = 'other'
+
+            bill.add_action(
+                actor=action_actor,
+                action=action_text,
+                date=action_date,
+                type=action_type
+            )
+
 
     def actor_from_action(self, bill, action):
         """


### PR DESCRIPTION
AZ: Add actions for Transmit to [house/senate/governor/secretary of state], and governor sign/veto, and PDF fallback for versions with no HTML copy.