### PR TITLE
IL: Added subject matter field to description and fixed participant

### DIFF
--- a/openstates/il/events.py
+++ b/openstates/il/events.py
@@ -4,7 +4,6 @@ import re
 from openstates.utils import LXMLMixin
 from billy.scrape.events import Event, EventScraper
 
-import lxml.html
 import pytz
 
 urls = {
@@ -20,8 +19,8 @@ class ILEventScraper(EventScraper, LXMLMixin):
     def scrape_page(self, url, session, chamber):
         page = self.lxmlize(url)
 
-        ctty_name = page.xpath("//span[@class='heading']")[0].text_content()
-
+        ctty_name = page.xpath("//span[@class='heading']")[0].text_content().replace(
+            "Hearing Notice For ", "")
         tables = page.xpath("//table[@cellpadding='3']")
         info = tables[0]
         rows = info.xpath(".//tr")
@@ -33,7 +32,8 @@ class ILEventScraper(EventScraper, LXMLMixin):
             metainf[key] = value
 
         where = metainf['Location:']
-        description = ctty_name
+        subject_matter = metainf['Subject Matter:']
+        description = "{}, {}".format(ctty_name, subject_matter)
 
         datetime = metainf['Scheduled Date:']
         datetime = re.sub("\s+", " ", datetime)


### PR DESCRIPTION
Fixed #1668

New Updates:-

`"description": "Appropriations II, Subject Matter on: FY18 budget request of the following agencies: SB2157-WIU, SB2158-ISU, SB2159-NIU, SB2160-SIU, SB2161-U of I, SB 2157, SB 2158, SB 2159, SB 2160, SB 2161"`

and

`"participant": "Appropriations II",` instead of  `"participant": "Hearing Notice For  Appropriations II"`

Let me know If we don't need `Subject Matter on:` in `description`. 