### PR TITLE
HI: Parse bill identifier from url.

### DIFF
--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -3,7 +3,7 @@ import lxml.html
 import re
 
 from .utils import get_short_codes
-from urlparse import urlparse
+import urlparse
 
 from billy.scrape.bills import BillScraper, Bill
 from billy.scrape.votes import Vote
@@ -167,9 +167,8 @@ class HIBillScraper(BillScraper):
     def scrape_bill(self, session, chamber, bill_type, url):
         bill_html = self.get(url).text
         bill_page = lxml.html.fromstring(bill_html)
-        scraped_bill_id = bill_page.xpath(
-            "//a[contains(@id, 'LinkButtonMeasure')]")[0].text_content()
-        bill_id = scraped_bill_id.split(' ')[0]
+        qs = dict(urlparse.parse_qsl(urlparse.urlparse(url).query))
+        bill_id = '{}{}'.format(qs['billtype'], qs['billnumber'])
         versions = bill_page.xpath( "//table[contains(@id, 'GridViewVersions')]" )[0]
 
         tables = bill_page.xpath("//table")


### PR DESCRIPTION
Handle cases like http://capitol.hawaii.gov/measure_indiv.aspx?billtype=SB&billnumber=1183&year=2017, which has the correct url but not the normal markup. Should resolve #1696.