### PR TITLE
MT, NC: session_list() movement

### DIFF
--- a/billy_metadata/mt.py
+++ b/billy_metadata/mt.py
@@ -32,19 +32,19 @@ metadata = {
         '2011': {'display_name': '2011 Regular Session',
                  'years': [2011, 2012],
                  '_scraped_name': '2011 Regular Session',
-                },
+                 },
         '2013': {'display_name': '2013 Regular Session',
                  'years': [2013, 2014],
                  '_scraped_name': '2013 Regular Session',
-                },
+                 },
         '2015': {'display_name': '2015 Regular Session',
                  'years': [2015],
                  '_scraped_name': '2015 Regular Session',
-                },
+                 },
         '2017': {'display_name': '2017 Regular Session',
                  'years': [2017],
                  '_scraped_name': '2017 Regular Session',
-                },
+                 },
     },
     'feature_flags': ['influenceexplorer'],
     '_ignored_scraped_sessions': [
@@ -60,13 +60,3 @@ metadata = {
         '1999 Regular Session',
         '1999 Special     Session']
 }
-
-
-def session_list():
-    from billy.scrape.utils import url_xpath
-    return url_xpath('http://leg.mt.gov/css/bills/Default.asp',
-        "//td[@id='cont']/ul/li/a/text()")
-
-
-def extract_text(doc, data):
-    return text_after_line_numbers(pdfdata_to_text(data))

--- a/billy_metadata/nc.py
+++ b/billy_metadata/nc.py
@@ -1,5 +1,4 @@
 import datetime
-import lxml
 
 metadata = dict(
     name='North Carolina',
@@ -12,40 +11,40 @@ metadata = dict(
         'lower': {'name': 'House', 'title': 'Representative'},
     },
     terms=[
-        #{'name': '1985-1986',
+        # {'name': '1985-1986',
         # 'sessions': ['1985', '1985E1'],
         # 'start_year': 1985, 'end_year': 1986},
-        #{'name': '1987-1988',
+        # {'name': '1987-1988',
         # 'sessions': ['1987'],
         # 'start_year': 1987, 'end_year': 1988},
-        #{'name': '1989-1990',
+        # {'name': '1989-1990',
         # 'sessions': ['1989', '1989E1', '1989E2'],
         # 'start_year': 1989, 'end_year': 1990},
-        #{'name': '1991-1992',
+        # {'name': '1991-1992',
         # 'sessions': ['1991', '1991E1'],
         # 'start_year': 1991, 'end_year': 1992},
-        #{'name': '1993-1994',
+        # {'name': '1993-1994',
         # 'sessions': ['1993', '1993E1'],
         # 'start_year': 1993, 'end_year': 1994},
-        #{'name': '1995-1996',
+        # {'name': '1995-1996',
         # 'sessions': ['1995', '1995E1', '1995E2'],
         # 'start_year': 1995, 'end_year': 1996},
-        #{'name': '1997-1998',
+        # {'name': '1997-1998',
         # 'sessions': ['1997', '1997E1'],
         # 'start_year': 1997, 'end_year': 1998},
-        #{'name': '1999-2000',
+        # {'name': '1999-2000',
         # 'sessions': ['1999', '1999E1', '1999E2'],
         # 'start_year': 1999, 'end_year': 2000},
-        #{'name': '2001-2002',
+        # {'name': '2001-2002',
         # 'sessions': ['2001', '2001E1'],
         # 'start_year': 2001, 'end_year': 2002},
-        #{'name': '2003-2004',
+        # {'name': '2003-2004',
         # 'sessions': ['2003', '2003E1', '2003E2', '2003E3'],
         # 'start_year': 2003, 'end_year': 2004},
-        #{'name': '2005-2006',
+        # {'name': '2005-2006',
         # 'sessions': ['2005'],
         # 'start_year': 2005, 'end_year': 2006},
-        #{'name': '2007-2008',
+        # {'name': '2007-2008',
         # 'sessions': ['2007', '2007E1', '2007E3'],
         # 'start_year': 2007, 'end_year': 2008},
         {'name': '2009-2010',
@@ -124,16 +123,3 @@ metadata = dict(
         '1986 Special Session', '1985-1986 Session'],
     feature_flags=['subjects', 'influenceexplorer'],
 )
-
-
-def session_list():
-    from billy.scrape.utils import url_xpath
-    return url_xpath('http://www.ncleg.net',
-                     '//select[@name="sessionToSearch"]/option/text()')
-
-
-def extract_text(doc, data):
-    doc = lxml.html.fromstring(data)
-    text = ' '.join([x.text_content() for x in
-                     doc.xpath('//p[starts-with(@class, "a")]')])
-    return text

--- a/openstates/mt/__init__.py
+++ b/openstates/mt/__init__.py
@@ -84,6 +84,6 @@ class Montana(Jurisdiction):
         yield lower
 
     def get_session_list(self):
-        from billy.scrape.utils import url_xpath
+        from openstates.utils.lxmlize import url_xpath
         return url_xpath('http://leg.mt.gov/css/bills/Default.asp',
                          "//td[@id='cont']/ul/li/a/text()")

--- a/openstates/mt/__init__.py
+++ b/openstates/mt/__init__.py
@@ -82,3 +82,8 @@ class Montana(Jurisdiction):
         yield legislature
         yield upper
         yield lower
+
+    def get_session_list(self):
+        from billy.scrape.utils import url_xpath
+        return url_xpath('http://leg.mt.gov/css/bills/Default.asp',
+                         "//td[@id='cont']/ul/li/a/text()")

--- a/openstates/nc/__init__.py
+++ b/openstates/nc/__init__.py
@@ -1,3 +1,4 @@
+import lxml
 from pupa.scrape import Jurisdiction, Organization
 from .people import NCPersonScraper
 from .committees import NCCommitteeScraper
@@ -145,3 +146,14 @@ class NorthCarolina(Jurisdiction):
         yield legislature
         yield upper
         yield lower
+
+    def get_session_list(self):
+        from billy.scrape.utils import url_xpath
+        return url_xpath('http://www.ncleg.net',
+                         '//select[@name="sessionToSearch"]/option/text()')
+
+    def extract_text(self, doc, data):
+        doc = lxml.html.fromstring(data)
+        text = ' '.join([x.text_content() for x in
+                         doc.xpath('//p[starts-with(@class, "a")]')])
+        return text

--- a/openstates/nc/__init__.py
+++ b/openstates/nc/__init__.py
@@ -148,7 +148,7 @@ class NorthCarolina(Jurisdiction):
         yield lower
 
     def get_session_list(self):
-        from billy.scrape.utils import url_xpath
+        from openstates.utils.lxmlize import url_xpath
         return url_xpath('http://www.ncleg.net',
                          '//select[@name="sessionToSearch"]/option/text()')
 


### PR DESCRIPTION
Just noticed it. So moved `session_list()` to __init__.py file for MT and NC.

Note:- Removed `extract_text()` from Montana's __init__.py file. If we need this one then should I add `text_after_line_numbers() & pdfdata_to_text()` to `openstates/utils`? These functions are used in other state __init__.py files also. 