### PR TITLE
MI: Handle committee names with misspelled "committeee".

### DIFF
--- a/openstates/mi/committees.py
+++ b/openstates/mi/committees.py
@@ -76,7 +76,7 @@ class MICommitteeScraper(Scraper):
         headers = doc.xpath('(//div[@class="row"])[2]//h1')
         assert len(headers) == 1
         name = ' '.join(headers[0].xpath('./text()'))
-        name = name.replace(' Committee', '')
+        name = re.sub(r'\s+Committee.*$', '', name)
 
         com = Organization(chamber='upper', name=name, classification='committee')
 


### PR DESCRIPTION
Handle committee titles like "Commerce Committeee", which otherwise
resolves to "Commercee".

Should fix issues like:

<img width="798" alt="screen shot 2017-05-20 at 8 42 36 pm" src="https://cloud.githubusercontent.com/assets/1633460/26280337/e63cfd9e-3d9c-11e7-97e2-a0e7bbfb424e.png">

If we have a contact at Michigan, we could also ask them to fix the typo in the header of http://www.senate.michigan.gov/committee/commerce.html.