### PR TITLE
ND: bills IndexError problem solved in scrape_objects

### DIFF
--- a/openstates/nd/bills.py
+++ b/openstates/nd/bills.py
@@ -166,11 +166,14 @@ class NDBillScraper(Scraper, LXMLMixin):
         bills = page.xpath("//a[contains(@href, 'bill-actions')]")
         for bill in bills:
             bt = bill.text_content().strip().split()
-            typ, idd = bt[0], bt[1]
-            bid = "%s %s" % (typ, idd)
-            if bid not in self.subjects.keys():
-                self.subjects[bid] = []
-            self.subjects[bid].append(subject)
+            try:
+                typ, idd = bt[0], bt[1]
+                bid = "%s %s" % (typ, idd)
+                if bid not in self.subjects.keys():
+                    self.subjects[bid] = []
+                self.subjects[bid].append(subject)
+            except IndexError:
+                self.warning("Bill ID and Type Not Found!")
 
     def scrape(self, session=None, chamber=None):
         if not session:


### PR DESCRIPTION
#1790
There is no `Bill ID and Type` listed on [Link](http://www.legis.nd.gov/assembly/65-2017/subject-index/sijudicial+branch.html) for `JUVENILE JUSTICE PROCESS STUDY` and their URLs are also broken.