### PR TITLE
WI: Add 2017 session and remove some redundant scraping.

### DIFF
--- a/billy_metadata/wi.py
+++ b/billy_metadata/wi.py
@@ -50,7 +50,7 @@ metadata = {
          'sessions': ['2015 Regular Session'],
          'start_year': 2015, 'end_year': 2016},
          {'name': '2017-2018',
-         'sessions': ['2017 Regular Session'],
+         'sessions': ['2017 Regular Session','January 2017 Special Session'],
          'start_year': 2016, 'end_year': 2018},
     ],
     'session_details': {
@@ -124,13 +124,19 @@ metadata = {
             'display_name': '2017 Regular Session',
             '_scraped_name': '2017 Regular Session',
         },
+        'January 2017 Special Session': {
+            'start_date': datetime.date(2017, 4, 4),
+            'type': 'special',
+            'display_name': 'January 2017 Special Session',
+            '_scraped_name': 'January 2017 Special Session',
+            'site_id': 'jr7'
+        },
     },
     'feature_flags': ['subjects',
                       'events',
                       'influenceexplorer'],
     '_ignored_scraped_sessions': [
         # The WI Website has multiple special sessions in the system with no data.
-        'January 2017 Special Session',
         'February 2015 Extraordinary Session',
         '2007 Regular Session', 'April 2008 Special Session',
         'March 2008 Special Session', 'December 2007 Special Session',

--- a/openstates/wi/__init__.py
+++ b/openstates/wi/__init__.py
@@ -106,9 +106,16 @@ class Wisconsin(Jurisdiction):
             "name": "2017 Regular Session",
             "start_date": "2017-01-03"
         },
+        {
+            'identifier': 'January 2017 Special Session',
+            'start_date': "2017-04-04",
+            'type': 'special',
+            'display_name': 'January 2017 Special Session',
+            '_scraped_name': 'January 2017 Special Session',
+            'site_id': 'jr7'
+        }
     ]
     ignored_scraped_sessions = [
-        "January 2017 Special Session",
         "February 2015 Extraordinary Session",
         "2007 Regular Session",
         "April 2008 Special Session",

--- a/openstates/wi/bills.py
+++ b/openstates/wi/bills.py
@@ -39,6 +39,8 @@ TIMEZONE = pytz.timezone('US/Central')
 
 
 class WIBillScraper(Scraper):
+    subjects = defaultdict(list)
+
     def scrape_subjects(self, year, site_id):
         last_url = None
         next_url = 'http://docs.legis.wisconsin.gov/%s/related/subject_index/index/' % year
@@ -47,8 +49,6 @@ class WIBillScraper(Scraper):
         # if you visit this page in your browser it is infinite-scrolled
         # but if you disable javascript you'll see the 'Down' links
         # that we use to scrape the data
-
-        self.subjects = defaultdict(list)
 
         while last_url != next_url:
             html = self.get(next_url).text
@@ -102,7 +102,8 @@ class WIBillScraper(Scraper):
         site_id = SESSION_SITE_IDS.get(session, 'reg')
         chamber_slug = {'upper': 'sen', 'lower': 'asm'}[chamber]
 
-        self.scrape_subjects(year, site_id)
+        if not self.subjects:
+            self.scrape_subjects(year, site_id)
 
         types = ('bill', 'joint_resolution', 'resolution')
 

--- a/openstates/wi/common.py
+++ b/openstates/wi/common.py
@@ -15,6 +15,7 @@ SESSION_TERMS = {
     '2015 Regular Session': '2015-2016',
 
     '2017 Regular Session': '2017-2018',
+    'January 2017 Special Session': '2017-2018',
 }
 
 SESSION_SITE_IDS = {
@@ -25,4 +26,5 @@ SESSION_SITE_IDS = {
     'October 2013 Special Session': 'oc3',
     'December 2013 Special Session': 'de3',
     'January 2014 Special Session': 'jr4',
+    'January 2017 Special Session': 'jr7',
 }


### PR DESCRIPTION
Add the now-active 2017 Special, and don't scrape subjects twice, since the generated mapping is for both lower and upper.