### PR TITLE
[WIP] TX Votes: parsing legislators' names more successfully

### DIFF
--- a/openstates/tx/votes.py
+++ b/openstates/tx/votes.py
@@ -54,35 +54,43 @@ def clean_journal(root):
 
 def names(el):
     text = (el.text or '') + (el.tail or '')
+    split_name_list = text.split(';')
+    if len(split_name_list) < 7:
+        # probably failed to properly split on semi-colons; try commas:
+        split_name_list = text.split(',')
 
     names = []
-    for name in text.split(';'):
+    for name in split_name_list:
         name = name.strip().replace('\r\n', '').replace('  ', ' ')
 
         if not name:
             continue
 
-        if name == 'Gonzalez Toureilles':
-            name = 'Toureilles'
-        elif name == 'Mallory Caraway':
-            name = 'Caraway'
-        elif name == 'Martinez Fischer':
-            name = 'Fischer'
-        elif name == 'Rios Ybarra':
-            name = 'Ybarra'
-
+        name = clean_name_special_cases(name)
         names.append(name)
 
     if names:
-        # First name will have stuff to ignore before an mdash
-        names[0] = clean_name(names[0]).strip()
+        # First item in the list will have stuff to ignore before an mdash
+        names[0] = clean_starting_name(names[0]).strip()
         # Get rid of trailing '.'
         names[-1] = names[-1][0:-1]
 
     return names
 
 
-def clean_name(name):
+def clean_name_special_cases(name):
+    if name == 'Gonzalez Toureilles':
+        name = 'Toureilles'
+    elif name == 'Mallory Caraway':
+        name = 'Caraway'
+    elif name == 'Martinez Fischer':
+        name = 'Fischer'
+    elif name == 'Rios Ybarra':
+        name = 'Ybarra'
+    return name
+
+
+def clean_starting_name(name):
     return re.split(r'[\u2014:]', name)[-1]
 
 


### PR DESCRIPTION
First attempt at addressing issue #1782.

The existing scraper would split the list of names on semi-colons. It looks like, for the latest session at least, the Senate used commas. (The House still used semi-colons.) You can see the effect of this on, for example, [SB 16](https://openstates.org/tx/bills/85/SB16/), where the House vote page lists a separate entry for each person, but the Senate vote page doesn't split out the names.

Good:
![image](https://user-images.githubusercontent.com/514037/27669332-c23080ec-5c4b-11e7-9a7f-b4ffc49b2278.png)

Bad:
![image](https://user-images.githubusercontent.com/514037/27669106-b46ee940-5c4a-11e7-9ad6-b1f570b432d7.png)

The attempt in this PR is to split by semi-colons, and if that result doesn't seem to have created a plausible number of separate names, try splitting by commas. This feels admittedly hacky. 

If it's not too much trouble, I would love advice on better ways to attempt the fix as well as a solid strategy for verifying that I didn't make it worse. I'm just spot-checking, which isn't robust enough.