### PR TITLE
OK: Replace proxy server usage with curl shell command

### DIFF
--- a/openstates/ok/committees.py
+++ b/openstates/ok/committees.py
@@ -1,10 +1,10 @@
 import re
 import lxml.html
 from pupa.scrape import Scraper, Organization
-from .utils import proxy_house_url
+from .utils import LXMLMixinOK
 
 
-class OKCommitteeScraper(Scraper):
+class OKCommitteeScraper(Scraper, LXMLMixinOK):
 
     def scrape(self, chamber=None):
         chambers = [chamber] if chamber is not None else ['upper', 'lower']
@@ -13,8 +13,7 @@ class OKCommitteeScraper(Scraper):
 
     def scrape_lower(self):
         url = "http://www.okhouse.gov/Committees/Default.aspx"
-        page = lxml.html.fromstring(self.get(proxy_house_url(url)).text)
-        page.make_links_absolute(url)
+        page = self.curl_lxmlize(url)
 
         parents = {}
 
@@ -38,8 +37,7 @@ class OKCommitteeScraper(Scraper):
             yield from self.scrape_lower_committee(name, parent, link.attrib['href'])
 
     def scrape_lower_committee(self, name, parent, url):
-        page = lxml.html.fromstring(self.get(proxy_house_url(url)).text)
-        page.make_links_absolute(url)
+        page = self.curl_lxmlize(url)
 
         if 'Joint' in name or (parent and 'Joint' in parent):
             chamber = 'joint'

--- a/openstates/ok/people.py
+++ b/openstates/ok/people.py
@@ -4,6 +4,7 @@ from pupa.scrape import Person, Scraper
 from openstates.utils import LXMLMixin, validate_email_address
 from .utils import LXMLMixinOK
 
+
 class OKPersonScraper(Scraper, LXMLMixin, LXMLMixinOK):
 
     _parties = {'R': 'Republican', 'D': 'Democratic', 'I': 'Independent'}

--- a/openstates/ok/people.py
+++ b/openstates/ok/people.py
@@ -2,10 +2,9 @@ import re
 import lxml
 from pupa.scrape import Person, Scraper
 from openstates.utils import LXMLMixin, validate_email_address
-from .utils import proxy_house_url
+from .utils import LXMLMixinOK
 
-
-class OKPersonScraper(Scraper, LXMLMixin):
+class OKPersonScraper(Scraper, LXMLMixin, LXMLMixinOK):
 
     _parties = {'R': 'Republican', 'D': 'Democratic', 'I': 'Independent'}
 
@@ -63,9 +62,8 @@ class OKPersonScraper(Scraper, LXMLMixin):
             yield from getattr(self, 'scrape_' + chamber + '_chamber')(term)
 
     def scrape_lower_chamber(self, term):
-        url = "http://www.okhouse.gov/Members/Default.aspx"
-
-        page = self.lxmlize(proxy_house_url(url))
+        url = "https://www.okhouse.gov/Members/Default.aspx"
+        page = self.curl_lxmlize(url)
 
         legislator_nodes = self.get_nodes(
             page,
@@ -112,9 +110,8 @@ class OKPersonScraper(Scraper, LXMLMixin):
 
             party = self._parties[party_text]
 
-            legislator_url = 'http://www.okhouse.gov/District.aspx?District=' + district
-
-            legislator_page = self.lxmlize(proxy_house_url(legislator_url))
+            legislator_url = 'https://www.okhouse.gov/District.aspx?District=' + district
+            legislator_page = self.curl_lxmlize(legislator_url)
 
             photo_url = self.get_node(
                 legislator_page,
@@ -142,7 +139,7 @@ class OKPersonScraper(Scraper, LXMLMixin):
         for bold in doc.xpath(xpath):
 
             # Get the address.
-            address_div = bold.getparent().itersiblings().next()
+            address_div = next(bold.getparent().itersiblings())
 
             # Get the room number.
             xpath = '//*[contains(@id, "CapitolRoom")]/text()'

--- a/openstates/ok/utils.py
+++ b/openstates/ok/utils.py
@@ -1,5 +1,22 @@
-OK_PROXY = 'https://dcyqmf3d8vr92.cloudfront.net'
+import subprocess
+import lxml.html
 
+class LXMLMixinOK(object):
+    def curl_lxmlize(self, url):
+        """Parses document into an LXML object and makes links absolute.
+        Outsources to curl as a workaround for the python ssl module's lack of
+        out-of-the-box handling of TLS 1.0 servers.
 
-def proxy_house_url(url):
-    return url.replace('http://www.okhouse.gov', OK_PROXY) + ('&os' if '?' in url else '')
+        Args:
+            url (str): URL of the document to parse.
+        Returns:
+            Element: Document node representing the page.
+        """
+
+        self.info('GET via curl subprocess: ' + url)
+        response = subprocess.run(['curl', '--silent', url],
+                                  stdout=subprocess.PIPE)
+        page = lxml.html.fromstring(response.stdout)
+        page.make_links_absolute(url)
+
+        return page

--- a/openstates/ok/utils.py
+++ b/openstates/ok/utils.py
@@ -1,6 +1,7 @@
 import subprocess
 import lxml.html
 
+
 class LXMLMixinOK(object):
     def curl_lxmlize(self, url):
         """Parses document into an LXML object and makes links absolute.


### PR DESCRIPTION
This is a workaround for getting pages off okhouse.gov's TLS 1.0 server, which python's core ssl module seems to have trouble talking to.

My system `curl` is compiled with GnuTLS, which may be the key to it working. I'm not sure whether a `curl` compiled with OpenSSL will also be successful.