### PR TITLE
[bugfix] RI votes imported #1813

### DIFF
--- a/billy_metadata/ri.py
+++ b/billy_metadata/ri.py
@@ -102,5 +102,4 @@ metadata = {
         '2008',
         '2007'
     ],
-    '_partial_vote_bill_id': True,
 }


### PR DESCRIPTION
This fixes issue #1813 by getting rid of a metadata parameter which controls a (seemingly deprecated) hack in billy.