### PR TITLE
AK: add new committee abbreviation

### DIFF
--- a/openstates/ak/bills.py
+++ b/openstates/ak/bills.py
@@ -35,6 +35,7 @@ class AKBillScraper(Scraper):
         'AM': 'Amend'}
 
     _comm_mapping = {
+        'AET': 'Arctic Policy, Economic Development, & Tourism',        
         'CRA': 'Community & Regional Affairs',
         'EDC': 'Education',
         'FIN': 'Finance',

--- a/openstates/ak/bills.py
+++ b/openstates/ak/bills.py
@@ -35,7 +35,7 @@ class AKBillScraper(Scraper):
         'AM': 'Amend'}
 
     _comm_mapping = {
-        'AET': 'Arctic Policy, Economic Development, & Tourism',        
+        'AET': 'Arctic Policy, Economic Development, & Tourism',
         'CRA': 'Community & Regional Affairs',
         'EDC': 'Education',
         'FIN': 'Finance',


### PR DESCRIPTION
Alaska changed the committee abbreviation for their Arctic Policy committee, which broke the scraper. I left the old one in to allow previous session scraping to continue to work.