### PR TITLE
VT: Remove special casing of Grand Isle district

### DIFF
--- a/openstates/vt/people.py
+++ b/openstates/vt/people.py
@@ -40,8 +40,6 @@ class VTPersonScraper(Scraper, LXMLMixin):
                 state_email = None
 
             district = info['District'].replace(" District", "")
-            if district == 'Grand Isle':
-                district = 'Chittenden-Grand Isle'
 
             leg = Person(
                 primary_org=self.CHAMBERS[info['Title']],


### PR DESCRIPTION
Grand Isle is an actual state senate district (https://ballotpedia.org/Vermont_State_Senate_Grand_Isle_District). I assume there was a case where the state house district of Grand Isle-Chittenden was incorrectly listed somewhere, but I'm not seeing that now.