### PR TITLE
FL: Fix No executive actions recorded 

### DIFF
--- a/openstates/fl/bills.py
+++ b/openstates/fl/bills.py
@@ -155,6 +155,10 @@ class BillDetail(Page):
                     atype.append('passage')
                 elif action.startswith('CS passed'):
                     atype.append('passage')
+                elif action == 'Approved by Governor':
+                    atype.append('executive-signature')
+                elif action == 'Vetoed by Governor':
+                    atype.append('executive-veto')
 
                 self.obj.add_action(action, date, organization=actor, chamber=chamber,
                                     classification=atype)


### PR DESCRIPTION
Added to action type elseif to identify executive signature and veto actions.

Fixes #1950 