### PR TITLE
CT: Classify line item vetoes

### DIFF
--- a/openstates/ct/bills.py
+++ b/openstates/ct/bills.py
@@ -262,6 +262,9 @@ class CTBillScraper(Scraper):
                     act_type.append('committee-passage-%s' %
                                     match.group(1).lower())
 
+                if (re.match(r'^LINE ITEM VETOED', action)):
+                    act_type.append('executive-veto-line-item')
+
                 if not act_type:
                     act_type = None
 


### PR DESCRIPTION
State: CT 

CT has some line-item vetoes now, so correctly classify those actions.

Test bill: 
https://openstates.org/ct/bills/2017/SB1502/