### PR TITLE
AL: Add action for executive-signature to action map

### DIFF
--- a/openstates/al/bills.py
+++ b/openstates/al/bills.py
@@ -37,7 +37,7 @@ _action_re = (
     ('Lost in', 'failure'),
     ('Favorable from', 'committee-passage-favorable'),
     # Signature event does not appear to be listed as a specific action
-    ('Assigned Act No.' 'executive-signature'),
+    ('Assigned Act No' 'executive-signature'),
 )
 ()
 

--- a/openstates/al/bills.py
+++ b/openstates/al/bills.py
@@ -36,7 +36,10 @@ _action_re = (
     ('Joint Rule 11', ['introduction', 'passage']),
     ('Lost in', 'failure'),
     ('Favorable from', 'committee-passage-favorable'),
+    # Signature event does not appear to be listed as a specific action
+    ('Assigned Act No.' 'executive-signature'),
 )
+()
 
 
 def _categorize_action(action):


### PR DESCRIPTION
Alabama has no entries for 2017 showing bill signature.  In reviewing the data on the Alabama site there doesn't appear to be a specific entry in the actions for the governor's signature, just entries where it is sent to the governor and then an entry where it is "Assigned Act".  This assignment as indicated in their glossary denotes a completed and signed bill.  Lacking a better option, added this to the map to indicate a passed and signed bill.

Eric