### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN apt-get update && apt-get install -y \
     mysql-server \
     libmysqlclient-dev \
     mongodb-org-tools \
-    mdbtools \ 
+    mdbtools \
     postgresql-client-9.5
-    
+
 
 RUN mkdir -p /opt/openstates/
 RUN mkdir -p /var/run/mysqld/
@@ -59,4 +59,4 @@ ADD . /opt/openstates/openstates
 RUN /opt/openstates/venv-pupa/bin/pip install -r /opt/openstates/openstates/requirements.txt
 
 WORKDIR /opt/openstates/openstates/
-ENTRYPOINT [/opt/openstates/openstates/pupa-scrape.sh]
+ENTRYPOINT ["/opt/openstates/openstates/pupa-scrape.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y \
     mysql-server \
     libmysqlclient-dev \
     mongodb-org-tools \
-    mdbtools \
     postgresql-client-9.5
 
 


### PR DESCRIPTION
Hello,

Was running into an issue w/ https://hub.docker.com/r/openstates/openstates/ image, where running `docker run openstates/openstates nc --fastmode` would result in the following error:

```
nc: 1: nc: [/opt/openstates/openstates/pupa-scrape.sh]: not found
```

By wrapping the `ENTRYPOINT` executable in double quotes, I was able to build an image locally and run the `docker run ...` command from above successfully.

Additionally, I noticed the `mdbtools` package was listed twice, so I removed to second occurrence. Happy to undo if that was intentional.

The only other change was a whitespace removal triggered by saving the file in my Atom text editor.

Thanks!