### PR TITLE
Updated README examples to reflect new service name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,14 +13,14 @@ Getting Started
 We use `Docker <https://www.docker.com/products/docker>`_ to provide a reproducible development environment. Make sure
 you have Docker installed.  Inside of the directory you cloned this project into::
 
-  docker-compose run --rm openstates <abbreviated state code>  # Scrapes the state indicated by the code e.g. "ny"
+  docker-compose run --rm scrape <abbreviated state code>  # Scrapes the state indicated by the code e.g. "ny"
 
 This project runs on top of `billy <https://github.com/openstates/billy>`_, a scraping framework for government data.
 Our Docker container runs the ``billy-update`` command
 (`billy-update docs <http://billy.readthedocs.io/en/latest/scripts.html>`_) with whatever arguments you put at the end
 of ``docker run``. For example, you can limit the scrape to Tennessee's (tn) state senators using::
 
-  docker-compose run --rm openstates tn --upper --legislators
+  docker-compose run --rm scrape tn --upper --legislators
 
 Check out the `writing scrapers guide <http://docs.openstates.org/en/latest/contributing/getting-started.html>`_ to understand how the scrapers work & how to contribute.
 
@@ -28,6 +28,6 @@ Testing
 =======
 To run all tests::
 
-  docker-compose run --rm --entrypoint=nosetests openstates /srv/openstates-web/openstates
+  docker-compose run --rm --entrypoint=nosetests scrape /srv/openstates-web/openstates
 
 Note that Illinois (il) is the only state with tests right now.


### PR DESCRIPTION
The service name changed in https://github.com/openstates/openstates/commit/a2e0438bedf982d1b42496fe6f1d77180ebb17f0