### PR TITLE
Add additional environment variable to allow scrape to skip billy usage

### DIFF
--- a/pupa-scrape.sh
+++ b/pupa-scrape.sh
@@ -13,6 +13,10 @@ export PYTHONPATH=./openstates
 
 $PUPA_ENV/bin/pupa ${PUPA_ARGS:-} update $state "$@"
 
+if [ "$SKIP_BILLY" = true ]; then
+  exit 0
+fi
+
 export PUPA_DATA_DIR='../openstates/_data'
 export PYTHONPATH=./billy_metadata/
 $BILLY_ENV/bin/python -m pupa2billy.run $state


### PR DESCRIPTION
Tiny change to allow for skipping billy usage via `SKIP_BILLY=true` environment variable. We only need the pupa output for a current project, so figured this would be a nice option for users that may not require billy as well.