### PR TITLE
Update xpath for roll call in PA to accommodate recent html changes; fixes #1968

### DIFF
--- a/openstates/pa/bills.py
+++ b/openstates/pa/bills.py
@@ -232,10 +232,24 @@ class PABillScraper(Scraper):
             type = 'other'
             motion = link.text_content()
 
-        yeas = int(page.xpath("//div/span[text() = 'YEAS']/..")[0].getnext().text)
-        nays = int(page.xpath("//div/span[text() = 'NAYS']/..")[0].getnext().text)
-        lve = int(page.xpath("//div/span[text() = 'E']/..")[0].getnext().text)
-        nv = int(page.xpath("//div/span[text() = 'N/V']/..")[0].getnext().text)
+        # Looks like for "YEAS" and "NAYS" counts, PA has multiple HTML
+        # formats: one where the "YEAS" text node is nested within a span
+        # element, and another where the text node is a direct child of the div
+        # element
+        yeas_elements = page.xpath("//div/span[text() = 'YEAS']/..")
+        if len(yeas_elements) == 0:
+            yeas_elements = page.xpath("//div[text()[normalize-space() = 'YEAS']]")
+        yeas = int(yeas_elements[0].getnext().text)
+
+        nays_elements = page.xpath("//div/span[text() = 'NAYS']/..")
+        if len(nays_elements) == 0:
+            nays_elements = page.xpath("//div[text()[normalize-space() = 'NAYS']]")
+        nays = int(nays_elements[0].getnext().text)
+
+        # "LVE" and "N/V" have been moved up as direct children of the div
+        # element
+        lve = int(page.xpath("//div[text()[normalize-space() = 'LVE']]")[0].getnext().text)
+        nv = int(page.xpath("//div[text()[normalize-space() = 'N/V']]")[0].getnext().text)
         other = lve + nv
 
         vote = VoteEvent(


### PR DESCRIPTION
Looks like PA updated their HTML structure so made some minor tweaks to xpath to grab roll call counts and avoid the scraper breaking. I also noticed a couple different HTML formats, so "YEAS" and "NAYS" have conditionals. E.g., one of the `lxml` parsed pages looked like this (snippet):

```html
<div style="margin-left:10px;" id="RCVotesSum">                
                    <div style="float:left;" class="RCVotesHeaders"><span style="color: green;"><span aria-hidden="true" class="icon icon-thumbs-up"></span></span> <span style="color: black;">YEAS</span></div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">143</div><br>
                    <div style="float:left;" class="RCVotesHeaders"><span style="color: red;"><span aria-hidden="true" class="icon icon-thumbs-up-2"></span></span> <span style="color: black;">NAYS</span></div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">53</div><br>
                    <div style="float:left;" class="RCVotesHeaders"><span style="font-weight: bold; width: 17px; display:inline-block; padding-left: 1px;">E</span> LVE</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">7</div><br>
                    <div style="float:left;" class="RCVotesHeaders"><span style="width: 18px; display:inline-block;"><span aria-hidden="true" class="icon icon-x"></span></span> N/V</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">0</div><br>
                    <div style="border-top:1pt solid #000000;" class="RCVotesLine">&#160;</div>                
                    <div class="RCVotesTotalCount">TOTAL
                        <div style="float:right;">203</div>
                    </div>
                </div>
```

while another parsed page looked like this (snippet of whole page):

```html
<div style="margin-left:10px;" id="RCVotesSum">                
                    <div style="float:left;" class="RCVotesHeaders">YEAS</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">40</div><br>
                    <div style="float:left;" class="RCVotesHeaders">NAYS</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">9</div><br>
                    <div style="float:left;" class="RCVotesHeaders">LVE</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">0</div><br>
                    <div style="float:left;" class="RCVotesHeaders">N/V</div><div style="float:left; text-align:right; padding-right:5px;" class="RCVotesTotals">1</div><br>
                    <div style="border-top:1pt solid #000000;" class="RCVotesLine">&#160;</div>                
                    <div class="RCVotesTotalCount">TOTAL
                        <div style="float:right;">50</div>
                    </div>
                </div>
```

So far, so good when running `docker-compose run --rm scrape pa bills --scrape`. Thanks!