### PR TITLE
Patch SC scraper; fixes #1948

### DIFF
--- a/openstates/sc/bills.py
+++ b/openstates/sc/bills.py
@@ -116,12 +116,6 @@ class SCBillScraper(Scraper):
         for option in doc.xpath('//option')[2:]:
             subject = option.text
             code = option.get('value')
-
-            if code == '1130':
-                # added Nov 2017, this code broke the scrape for a few weeks
-                self.warning('skipping 1130 - broken page')
-                continue
-
             url = '%s?AORB=B&session=%s&indexcode=%s' % (subject_search_url,
                                                          session_code, code)
             data = self.get(url).text

--- a/openstates/sc/bills.py
+++ b/openstates/sc/bills.py
@@ -9,6 +9,12 @@ from pupa.scrape import Scraper, Bill, VoteEvent
 from pupa.utils.generic import convert_pdf
 import lxml.html
 
+# Workaround to prevent chunking error (thanks @showerst)
+#
+# @see https://stackoverflow.com/a/37818792/1858091
+import http.client
+http.client.HTTPConnection._http_vsn = 10
+http.client.HTTPConnection._http_vsn_str = 'HTTP/1.0'
 
 def action_type(action):
     """

--- a/openstates/sc/bills.py
+++ b/openstates/sc/bills.py
@@ -13,8 +13,10 @@ import lxml.html
 #
 # @see https://stackoverflow.com/a/37818792/1858091
 import http.client
+
 http.client.HTTPConnection._http_vsn = 10
 http.client.HTTPConnection._http_vsn_str = 'HTTP/1.0'
+
 
 def action_type(action):
     """


### PR DESCRIPTION
Patches scraper by preventing the SC server from sending chunked encoding (thanks for the heads up @showerst) via adjusting some `http.client.HTTPConnection` properties. Also remove bypassing of `indexcode=1130` as the HTTP workaround seems to allow that page to load.

I was originally experiencing the error when requesting http://www.scstatehouse.gov/subjectsearch.php?AORB=B&session=122&indexcode=1120. Both `1120` and `1130` are working for me now. Thanks!