### PR TITLE
WA: fix leg val errs: skip empty contact details

### DIFF
--- a/openstates/wa/people.py
+++ b/openstates/wa/people.py
@@ -81,16 +81,16 @@ class WAPersonScraper(Scraper, LXMLMixin):
 
             if capitol_address:
                 leg.add_contact_detail(type='address', value=capitol_address,
-                                        note='Capitol Office')
+                                       note='Capitol Office')
             if email:
                 leg.add_contact_detail(type='email', value=email,
-                                        note='Capitol Office')
+                                       note='Capitol Office')
             if capitol_phone:
                 leg.add_contact_detail(type='voice', value=capitol_phone,
-                                        note='Capitol Office')
+                                       note='Capitol Office')
             if capitol_fax:
                 leg.add_contact_detail(type='fax', value=str(capitol_fax),
-                                        note='Capitol Office')
+                                       note='Capitol Office')
             _has_district_office = member.xpath('.//div[@class="memberColumnTitle" and'
                                                 'text()=" District Office"]')
             if _has_district_office:
@@ -113,11 +113,11 @@ class WAPersonScraper(Scraper, LXMLMixin):
 
                 if district_phone:
                     leg.add_contact_detail(type='voice', value=district_phone,
-                                            note='District Office')
+                                           note='District Office')
 
                 if district_address:
                     leg.add_contact_detail(type='address', value=district_address,
-                                            note='District Office')
+                                           note='District Office')
             leg.add_source(index_url)
             leg.add_link(index_url)
             yield leg

--- a/openstates/wa/people.py
+++ b/openstates/wa/people.py
@@ -81,16 +81,16 @@ class WAPersonScraper(Scraper, LXMLMixin):
 
             if capitol_address:
                 leg.add_contact_detail(type='address', value=capitol_address,
-                                   note='Capitol Office')
+                                        note='Capitol Office')
             if email:
                 leg.add_contact_detail(type='email', value=email,
-                                   note='Capitol Office')
+                                        note='Capitol Office')
             if capitol_phone:
                 leg.add_contact_detail(type='voice', value=capitol_phone,
-                                   note='Capitol Office')
+                                        note='Capitol Office')
             if capitol_fax:
                 leg.add_contact_detail(type='fax', value=str(capitol_fax),
-                                   note='Capitol Office')
+                                        note='Capitol Office')
             _has_district_office = member.xpath('.//div[@class="memberColumnTitle" and'
                                                 'text()=" District Office"]')
             if _has_district_office:
@@ -113,11 +113,11 @@ class WAPersonScraper(Scraper, LXMLMixin):
 
                 if district_phone:
                     leg.add_contact_detail(type='voice', value=district_phone,
-                                       note='District Office')
+                                            note='District Office')
 
                 if district_address:
                     leg.add_contact_detail(type='address', value=district_address,
-                                       note='District Office')
+                                            note='District Office')
             leg.add_source(index_url)
             leg.add_link(index_url)
             yield leg

--- a/openstates/wa/people.py
+++ b/openstates/wa/people.py
@@ -79,13 +79,17 @@ class WAPersonScraper(Scraper, LXMLMixin):
                     district_num,
                     position)).strip()
 
-            leg.add_contact_detail(type='address', value=capitol_address,
+            if capitol_address:
+                leg.add_contact_detail(type='address', value=capitol_address,
                                    note='Capitol Office')
-            leg.add_contact_detail(type='email', value=email,
+            if email:
+                leg.add_contact_detail(type='email', value=email,
                                    note='Capitol Office')
-            leg.add_contact_detail(type='voice', value=capitol_phone,
+            if capitol_phone:
+                leg.add_contact_detail(type='voice', value=capitol_phone,
                                    note='Capitol Office')
-            leg.add_contact_detail(type='fax', value=str(capitol_fax),
+            if capitol_fax:
+                leg.add_contact_detail(type='fax', value=str(capitol_fax),
                                    note='Capitol Office')
             _has_district_office = member.xpath('.//div[@class="memberColumnTitle" and'
                                                 'text()=" District Office"]')
@@ -107,10 +111,12 @@ class WAPersonScraper(Scraper, LXMLMixin):
                 except AssertionError:
                     pass
 
-                leg.add_contact_detail(type='voice', value=district_phone,
+                if district_phone:
+                    leg.add_contact_detail(type='voice', value=district_phone,
                                        note='District Office')
 
-                leg.add_contact_detail(type='address', value=district_address,
+                if district_address:
+                    leg.add_contact_detail(type='address', value=district_address,
                                        note='District Office')
             leg.add_source(index_url)
             leg.add_link(index_url)


### PR DESCRIPTION
Fixes #1986.
It might make sense to log the cases where these content details are blank, but I'd guess not.
It might make sense to put an empty-check in add_content_detail, log and skip empties there.