### PR TITLE
MO: fixed bill subject scraper and Senate committee scraper - everything should be working now

### DIFF
--- a/openstates/mo/__init__.py
+++ b/openstates/mo/__init__.py
@@ -15,7 +15,7 @@ class Missouri(Jurisdiction):
     url = "http://www.moga.mo.gov/"
     scrapers = {
         'bills': MOBillScraper,
-        'votes': MOVoteScraper,
+        #'votes': MOVoteScraper,
         'people': MOPersonScraper,
         'committees': MOCommitteeScraper,
     }
@@ -86,6 +86,7 @@ class Missouri(Jurisdiction):
             "classification": "primary",
             "identifier": "2018",
             "name": "2018 Regular Session",
+            "start_date": "2017-12-01",
         },
 
     ]

--- a/openstates/mo/bills.py
+++ b/openstates/mo/bills.py
@@ -266,18 +266,20 @@ class MOBillScraper(Scraper, LXMLMixin):
     def _scrape_house_subjects(self, session):
         self.info('Collecting subject tags from lower house.')
 
-        subject_list_url = 'http://house.mo.gov/subjectindexlist.aspx?year={}'\
+        subject_list_url = 'http://house.mo.gov/LegislationSP.aspx?code=R&category=subjectindex&year={}'\
             .format(session)
         subject_page = self.lxmlize(subject_list_url)
 
         # Create a list of all the possible bill subjects.
         subjects = self.get_nodes(
             subject_page,
-            '//ul[@id="subjectindexitems"]/div/li[1]/a[1]')
+            "//div[@id='ContentPlaceHolder1_panelParentDIV']/div[@id='panelDIV']//div[@id='ExpandedPanel']//a")
 
         # Find the list of bills within each subject.
         for subject in subjects:
-            self.info('Searching for bills in {}.'.format(subject.text))
+
+            subject_text = re.sub(r"\([0-9]+\).*", '', subject.text, re.IGNORECASE).strip()
+            self.info('Searching for bills in {}.'.format(subject_text))
 
             subject_page = self.lxmlize(subject.attrib['href'])
 
@@ -299,7 +301,7 @@ class MOBillScraper(Scraper, LXMLMixin):
                     continue
 
                 self.info('Found {}.'.format(bill_id))
-                self._subjects[bill_id].append(subject.text)
+                self._subjects[bill_id].append(subject_text)
 
     def _parse_house_actions(self, bill, url):
         bill.add_source(url)

--- a/openstates/mo/committees.py
+++ b/openstates/mo/committees.py
@@ -51,9 +51,13 @@ class MOCommitteeScraper(Scraper, LXMLMixin):
 
         chamber = 'upper'
 
-        if self._is_post_2015:
+        if self._is_post_2015 and self.latest_session() != session:
             url = '{base}{year}web/standing-committees'.format(
                 base=self._senate_url_base, year=session[2:])
+            comm_container_id = 'primary'
+        elif session==self.latest_session():
+            url = '{base}standing-committees'.format(
+            base=self._senate_url_base)
             comm_container_id = 'primary'
         else:
             url = '{base}{year}info/com-standing.htm'.format(


### PR DESCRIPTION
I also had to deactivate the MO vote scraper for now. It crashes with the error message that it didn't yield any vote objects (which is not surprising given that we're in the bill prefiling phase for 2018)