### PR TITLE
Patch California download service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     - "27017:27017"
   mysql:
     image: mysql
+    command: mysqld --max_allowed_packet=512M
     ports:
     - "3306:3306"
     environment:


### PR DESCRIPTION
I kept running into the following error when running `docker-compose run --rm ca-download`:

```
inflating: pubinfo_2017/LAW_SECTION_TBL_38203.lob
  inflating: pubinfo_2017/LAW_SECTION_TBL_89370.lob
  inflating: pubinfo_2017/LAW_SECTION_TBL_120559.lob
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/openstates/openstates/openstates/ca/download.py", line 361, in <module>
    get_current_year(contents)
  File "/opt/openstates/openstates/openstates/ca/download.py", line 354, in get_current_year
    load(dirname)
  File "/opt/openstates/openstates/openstates/ca/download.py", line 197, in load
    load_bill_versions(connection)
  File "/opt/openstates/openstates/openstates/ca/download.py", line 156, in load_bill_versions
    cursor.execute(sql, [encode_or_none(column) for column in row])
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/cursors.py", line 247, in execute
    res = self._query(query)
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/cursors.py", line 411, in _query
    rowcount = self._do_query(q)
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/cursors.py", line 374, in _do_query
    db.query(q)
  File "/opt/openstates/venv-pupa/lib/python3.5/site-packages/MySQLdb/connections.py", line 277, in query
    _mysql.connection.query(self, query)
_mysql_exceptions.OperationalError: (2006, 'MySQL server has gone away')
```

After poking around for a bit, it seemed that this could be caused by `mysqld` config's `max_allowed_packet` being too small, so I increased by overriding the `Dockerfile` `CMD` via `command` within `docker-compose.yml`. It looks like that worked for me!

Couple resources:

[Checking the allowed packet size within the `mysql` container](https://stackoverflow.com/a/5688506/1858091)
https://stackoverflow.com/a/8062538/1858091 and [comment](https://stackoverflow.com/questions/8062496/how-to-change-max-allowed-packet-size#comment25569678_8062538)

Note that when I re-tested this locally via `docker-compose`, I had to remove the old `mysql` container (i.e., `depends_on` in `ca-download`) and I also removed the `mysql` image. Thanks!