### PR TITLE
ME: add alternate wording for veto override action.

### DIFF
--- a/openstates/me/actions.py
+++ b/openstates/me/actions.py
@@ -27,6 +27,7 @@ rules = (
     Rule('COMMITTED to the (?P<committees>Committee on .+?)\.',
          'referral-committee'),
     Rule(r'VETO was NOT SUSTAINED', 'veto-override-passage'),
+    Rule(r'VETO was OVERRIDDEN', 'veto-override-passage'),
     Rule(r'VETO was SUSTAINED', 'veto-override-failure'),
     Rule(r'(?<![Aa]mendment)READ and (PASSED|ADOPTED)(, in concurrence)?\.$',
          'passage')


### PR DESCRIPTION
State: ME

Add alternate wording for veto override action classifier. See LD 949 ME 127