### PR TITLE
HI: fix html element ids in xpaths

### DIFF
--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -201,7 +201,7 @@ class HIBillScraper(Scraper):
                                legislative_session=prior_session,
                                relation_type="companion")
         prior = bill_page.xpath(
-            "//table[@id='ctl00_ContentPlaceHolderCol1_GridViewStatus']/tr/td/font/text()")[-1]
+            "//table[@id='ContentPlaceHolderCol1_GridViewStatus']/tr/td/font/text()")[-1]
         if 'carried over' in prior.lower():
             b.add_related_bill(identifier=bill_id,
                                legislative_session=prior_session,

--- a/openstates/hi/committees.py
+++ b/openstates/hi/committees.py
@@ -23,11 +23,11 @@ class HICommitteeScraper(Scraper):
     def get_committee_data(self, url, org):
         list_html = self.get(HI_URL_BASE + url).text
         list_page = lxml.html.fromstring(list_html)
-        chair_div = list_page.xpath("//div[@id='ctl00_ContentPlaceHolderCol1_PanelChair']/div")
-        chair = chair_div[0].xpath("//a[@id='ctl00_ContentPlaceHolderCol1_HyperLinkChair']")
-        vchair_div = list_page.xpath("//div[@id='ctl00_ContentPlaceHolderCol1_PanelViceChair']")
-        vice = vchair_div[0].xpath("//div/a[@id='ctl00_ContentPlaceHolderCol1_HyperLinkcvChair']")
-        members = list_page.xpath("//table[@id='ctl00_ContentPlaceHolderCol1_DataList1']/tr/td/a")
+        chair_div = list_page.xpath("//div[@id='ContentPlaceHolderCol1_PanelChair']/div")
+        chair = chair_div[0].xpath("//a[@id='ContentPlaceHolderCol1_HyperLinkChair']")
+        vchair_div = list_page.xpath("//div[@id='ContentPlaceHolderCol1_PanelViceChair']")
+        vice = vchair_div[0].xpath("//div/a[@id='ContentPlaceHolderCol1_HyperLinkcvChair']")
+        members = list_page.xpath("//table[@id='ContentPlaceHolderCol1_DataList1']/tr/td/a")
         for i in chair:
             org.add_member(i.text_content().strip(), role='chair')
         for i in vice:
@@ -39,7 +39,7 @@ class HICommitteeScraper(Scraper):
         URL = get_chamber_url(chamber)
         list_html = self.get(URL).text
         list_page = lxml.html.fromstring(list_html)
-        rows = list_page.xpath("//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']/tr")
+        rows = list_page.xpath("//table[@id='ContentPlaceHolderCol1_GridView1']/tr")
         for row in rows:
             tds = row.xpath("./td")
             clong = tds[1]

--- a/openstates/hi/events.py
+++ b/openstates/hi/events.py
@@ -38,7 +38,7 @@ class HIEventScraper(Scraper, LXMLMixin):
         get_short_codes(self)
         page = self.lxmlize(URL)
         table = page.xpath(
-            "//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']")[0]
+            "//table[@id='ContentPlaceHolderCol1_GridView1']")[0]
 
         for event in table.xpath(".//tr")[1:]:
             tds = event.xpath("./td")

--- a/openstates/hi/people.py
+++ b/openstates/hi/people.py
@@ -24,7 +24,7 @@ class HIPersonScraper(Scraper):
         ret = {"source": url, 'ctty': []}
 
         table = page.xpath(
-            "//table[@id='ctl00_ContentPlaceHolderCol1_GridViewMemberof']")
+            "//table[@id='ContentPlaceHolderCol1_GridViewMemberof']")
         if len(table) > 0:
             table = table[0]
         else:
@@ -49,7 +49,7 @@ class HIPersonScraper(Scraper):
     def scrape_leg_page(self, url):
         page = self.get_page(url)
         people = page.xpath(
-            "//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']")[0]
+            "//table[@id='ContentPlaceHolderCol1_GridView1']")[0]
         people = people.xpath('./tr')[1:]
         display_order = {
             "image": 0,

--- a/openstates/hi/utils.py
+++ b/openstates/hi/utils.py
@@ -8,7 +8,7 @@ def get_short_codes(scraper):
     list_html = scraper.get(SHORT_CODES).text
     list_page = lxml.html.fromstring(list_html)
     rows = list_page.xpath(
-        "//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']/tr")
+        "//table[@id='ContentPlaceHolderCol1_GridView1']/tr")
     scraper.short_ids = {
         "CONF": {
             "chamber": "joint",


### PR DESCRIPTION
The state's html element ids all dropped the "ctl00_" prefix.
Fixes #2018, at least in part.