### PR TITLE
ND: Ignore 2019-2020 session

### DIFF
--- a/openstates/nd/__init__.py
+++ b/openstates/nd/__init__.py
@@ -48,6 +48,7 @@ class NorthDakota(Jurisdiction):
         }
     ]
     ignored_scraped_sessions = [
+        "66th Legislative Assembly (2019-20)",
         "61st Legislative Assembly (2009-10)",
         "60th Legislative Assembly (2007-08)",
         "59th Legislative Assembly (2005-06)",


### PR DESCRIPTION
A year early, it's breaking the scrape.  No bobcat issue yet.