### PR TITLE
OH: convert legi keys to ints when retrieving for bill scrape.

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -333,8 +333,8 @@ class OHBillScraper(Scraper):
             doc = self.get(url.format(chamber=chamber))
             leg_json = doc.json()
             for leg in leg_json["items"]:
-                legislators[leg["med_id"]] = leg["displayname"]
-
+                if leg["med_id"]:
+                    legislators[int(leg["med_id"])] = leg["displayname"]
         return legislators
 
     def get_sponsor_name(self, sponsor):


### PR DESCRIPTION
The Ohio legislator ids are scraped as strings, but appear in roll calls as ints.  This patch converts the scraped strings to ints as they are retrieved.

Fixes #2036.
