### PR TITLE
ID: add 2018 session. (READY to merge)

### DIFF
--- a/billy_metadata/id.py
+++ b/billy_metadata/id.py
@@ -75,7 +75,7 @@ metadata = {
             'name': '2017-2018',
             'start_year': 2017,
             'end_year': 2018,
-            'sessions': ['2017'],
+            'sessions': ['2017', '2018'],
         },
     ],
     'session_details': {
@@ -202,6 +202,13 @@ metadata = {
             'end_date': datetime.date(2017, 4, 7),
             'display_name': '64th Legislature, 1st Regular Session (2017)',
             '_scraped_name': '2017 Session',
+        },
+        '2018' : {
+            'type': 'primary',
+            'start_date': datetime.date(2018, 1, 8),
+            'end_date': datetime.date(2018, 3, 27),
+            'display_name': '64th Legislature, 2nd Regular Session (2018)',
+            '_scraped_name': '2018 Session',
         },
     },
     'feature_flags': ['influenceexplorer'],

--- a/openstates/id/__init__.py
+++ b/openstates/id/__init__.py
@@ -77,6 +77,14 @@ class Idaho(Jurisdiction):
             "identifier": "2017",
             "name": "64th Legislature, 1st Regular Session (2017)",
             "start_date": "2017-01-09"
+        },
+        {
+            "_scraped_name": "2018 Session",
+            "classification": "primary",
+            "end_date": "2018-03-27",
+            "identifier": "2018",
+            "name": "64th Legislature, 2nd Regular Session (2018)",
+            "start_date": "2018-01-08"
         }
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
This patch so far just adds the session.
A partial fix to #2052, but see Jan 12 comment.

There's a second issue pending: the state's legislative subject index page http://legislature.idaho.gov/sessioninfo/2018/legislation/topicind is missing, breaking the scrape.  I've contacted the webmaster and will monitor.

  