### PR TITLE
MI: fix senate committee scraping.

### DIFF
--- a/openstates/mi/committees.py
+++ b/openstates/mi/committees.py
@@ -58,7 +58,7 @@ class MICommitteeScraper(Scraper):
             yield com
 
     def scrape_senate_committees(self):
-        url = 'http://www.senate.michigan.gov/committee.html'
+        url = 'http://www.senate.michigan.gov'
         html = self.get(url).text
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)


### PR DESCRIPTION
This fixes a problem mentioned in a comment on #2045 (but not the original problem).

The MI Senate committee list has been moved from a separate page to a dropdown on the main Senate page with the same structure.  Just changing the url was all that was required.