### PR TITLE
CT: add 2018 session (HOLD for bills)

### DIFF
--- a/billy_metadata/ct.py
+++ b/billy_metadata/ct.py
@@ -34,7 +34,7 @@ metadata = {
             'name': '2017-2018',
             'start_year': 2017,
             'end_year': 2018,
-            'sessions': ['2017'],
+            'sessions': ['2017', '2018'],
         },
     ],
     'session_details': {
@@ -67,6 +67,12 @@ metadata = {
         '2017': {
             'display_name': '2017 Regular Session',
             '_scraped_name': '2017',
+        },
+        '2018': {
+            'display_name': '2018 Regular Session',
+            'start_date': datetime.date(2018, 1, 10),
+            'end_date': datetime.date(2018, 5, 9),
+            '_scraped_name': '2018',
         },
     },
     'feature_flags': ['subjects', 'events', 'influenceexplorer'],

--- a/openstates/ct/__init__.py
+++ b/openstates/ct/__init__.py
@@ -64,6 +64,13 @@ class Connecticut(Jurisdiction):
             "start_date": "2017-01-04",
             "end_date": "2017-06-07",
         },
+        {
+            "_scraped_name": "2018",
+            "identifier": "2018",
+            "name": "2018 Regular Session",
+            "start_date": "2018-01-10",
+            "end_date": "2018-05-09",
+        },
     ]
     ignored_scraped_sessions = [
         "2010",


### PR DESCRIPTION
Fixes #2063.

CT blows up differently from other states from lack of bills.
Check the third (`sess_year`) column in ftp://ftp.cga.ct.gov/pub/data/bill_info.csv; when it's 2018, this will be good to go.

I'll monitor.

  