### PR TITLE
NH: add 2018 session; classify "bill of address" as "bill"

### DIFF
--- a/billy_metadata/nh.py
+++ b/billy_metadata/nh.py
@@ -16,7 +16,7 @@ metadata = {
          'start_year': 2013, 'end_year': 2014},
         {'name': '2015-2016', 'sessions': ['2015', '2016'],
          'start_year': 2015, 'end_year': 2016},
-        {'name': '2017-2018', 'sessions': ['2017'],
+        {'name': '2017-2018', 'sessions': ['2017', '2018'],
          'start_year': 2017, 'end_year': 2018}
     ],
     'session_details': {
@@ -54,6 +54,9 @@ metadata = {
                  },
         '2017': {'display_name': '2017 Regular Session',
                  '_scraped_name': '2017 Session',
+                 },
+        '2018': {'display_name': '2018 Regular Session',
+                 '_scraped_name': '2018 Session',
                  },
     },
     'feature_flags': ['subjects', 'influenceexplorer'],

--- a/openstates/nh/__init__.py
+++ b/openstates/nh/__init__.py
@@ -58,7 +58,14 @@ class NewHampshire(Jurisdiction):
             "name": "2017 Regular Session",
             "start_date": "2017-01-04",
             "end_date": "2017-06-30",
-        }
+        },
+        {
+            "_scraped_name": "2018 Session",
+            "end_date": "2018-06-30",
+            "identifier": "2018",
+            "name": "2018 Regular Session",
+            "start_date": "2018-01-03",
+        },
     ]
     ignored_scraped_sessions = [
         "2013 Session",

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -15,7 +15,8 @@ bill_type_map = {
     'CR': 'concurrent resolution',
     'JR': 'joint resolution',
     'CO': 'concurrent order',
-    # really "bill of address"; see https://github.com/opencivicdata/python-opencivicdata/issues/115
+    # really "bill of address"; 
+    # see https://github.com/opencivicdata/python-opencivicdata/issues/115
     'A': 'bill',
 }
 action_classifiers = [

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -15,7 +15,8 @@ bill_type_map = {
     'CR': 'concurrent resolution',
     'JR': 'joint resolution',
     'CO': 'concurrent order',
-    'A': 'address',
+    # really "bill of address"; see https://github.com/opencivicdata/python-opencivicdata/issues/115
+    'A': 'bill',
 }
 action_classifiers = [
     ('Minority Committee Report', None),        # avoid calling these passage

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -15,7 +15,7 @@ bill_type_map = {
     'CR': 'concurrent resolution',
     'JR': 'joint resolution',
     'CO': 'concurrent order',
-    # really "bill of address"; 
+    # really "bill of address";
     # see https://github.com/opencivicdata/python-opencivicdata/issues/115
     'A': 'bill',
 }


### PR DESCRIPTION
Fixes #2073.

This also band-aids a problem where a "bill of address" (similar to impeachment) has no good classification, by just classifying it as a "bill".  An OCD issue is submitted to add a good classification: see https://github.com/opencivicdata/python-opencivicdata/issues/115.