### PR TITLE
MN: ignore Dan Schoen

### DIFF
--- a/openstates/mn/people.py
+++ b/openstates/mn/people.py
@@ -100,7 +100,6 @@ class SenList(CSV):
         return leg
 
     def handle_page(self):
-        logger = logging.getLogger("pupa")
         yield super(SenList, self).handle_page()
         if not self.danSchoenSeen:
             raise AssertionError('Dan Schoen not seen, remove his kludge')

--- a/openstates/mn/people.py
+++ b/openstates/mn/people.py
@@ -16,6 +16,7 @@ PARTIES = {
 class SenList(CSV):
     url = 'http://www.senate.mn/members/member_list_ascii.php?ls='
     _html_url = 'http://www.senate.mn/members/index.php'
+    danSchoenSeen = False
 
     def __init__(self, scraper, url=None, *, obj=None, **kwargs):
         super().__init__(scraper, url=url, obj=obj, **kwargs)
@@ -52,6 +53,7 @@ class SenList(CSV):
             return
         # This Dan Schoen hack very probably can be removed after April 2018.
         if row['First Name'] == 'Dan' and row['Last Name'] == 'Schoen':
+            self.danSchoenSeen = True
             return
         name = '{} {}'.format(row['First Name'], row['Last Name'])
         party = PARTIES[row['Party']]
@@ -97,6 +99,12 @@ class SenList(CSV):
 
         return leg
 
+    def handle_page(self):
+        logger = logging.getLogger("pupa")
+        yield super(SenList, self).handle_page()
+        if not self.danSchoenSeen:
+            logger.error('Dan Schoen not seen, remove his kludge')
+            # https://github.com/openstates/openstates/pull/2088
 
 class RepList(Page):
     url = 'http://www.house.leg.state.mn.us/members/hmem.asp'

--- a/openstates/mn/people.py
+++ b/openstates/mn/people.py
@@ -106,6 +106,7 @@ class SenList(CSV):
             logger.error('Dan Schoen not seen, remove his kludge')
             # https://github.com/openstates/openstates/pull/2088
 
+
 class RepList(Page):
     url = 'http://www.house.leg.state.mn.us/members/hmem.asp'
     list_xpath = '//div[@id="hide_show_alpha_all"]/table/tr/td/table/tr'

--- a/openstates/mn/people.py
+++ b/openstates/mn/people.py
@@ -103,7 +103,7 @@ class SenList(CSV):
         logger = logging.getLogger("pupa")
         yield super(SenList, self).handle_page()
         if not self.danSchoenSeen:
-            logger.error('Dan Schoen not seen, remove his kludge')
+            raise AssertionError('Dan Schoen not seen, remove his kludge')
             # https://github.com/openstates/openstates/pull/2088
 
 

--- a/openstates/mn/people.py
+++ b/openstates/mn/people.py
@@ -50,6 +50,9 @@ class SenList(CSV):
     def handle_list_item(self, row):
         if not row['First Name']:
             return
+        # This Dan Schoen hack very probably can be removed after April 2018.
+        if row['First Name'] == 'Dan' and row['Last Name'] == 'Schoen':
+            return
         name = '{} {}'.format(row['First Name'], row['Last Name'])
         party = PARTIES[row['Party']]
         leg = Person(name=name, district=row['District'].lstrip('0'),


### PR DESCRIPTION
Fixes #2081.

This kludge ignores any Senator named Dan Schoen.

Dan Schoen resigned in November, but this is reflected in only one of the two source documents we use, breaking the scrape.  A special election in February will probably result in this being corrected at the state website, so I didn't bother them.

Present in http://www.senate.mn/members/member_list_ascii.php?ls=
but removed from http://www.senate.mn/members/index.php