### PR TITLE
UT: Fix joint committee chamber classification

### DIFF
--- a/openstates/ut/committees.py
+++ b/openstates/ut/committees.py
@@ -27,7 +27,7 @@ class UTCommitteeScraper(Scraper):
                 name = name[len('Senate '):]
                 chamber = 'upper'
             else:
-                chamber = 'joint'
+                chamber = 'legislature'
 
             c = Organization(
                 chamber=chamber,


### PR DESCRIPTION
@jamesturk, I mimicked your fix for Maine the other day; is `legislature` the proper setting in Pupa for these committees, to replace `joint` in Billy?