### PR TITLE
OK: Update session metadata for 2018

### DIFF
--- a/billy_metadata/ok.py
+++ b/billy_metadata/ok.py
@@ -25,7 +25,7 @@ metadata = dict(
         {'name': '2017-2018',
          'start_year': 2017,
          'end_year': 2018,
-         'sessions': ['2017-2018', '2017SS1']},
+         'sessions': ['2017SS1', '2017SS2', '2017-2018']},
         ],
     session_details={
         # On the Oklahoma website they list 2011/2012 as separate sessions, but
@@ -59,8 +59,8 @@ metadata = dict(
              },
         '2017-2018':
             {'display_name': '2017-2018 Regular Session',
-             'session_id': '1700',
-             '_scraped_name': '2017 Regular Session',
+             'session_id': '1800',
+             '_scraped_name': '2018 Regular Session',
              },
         '2017SS1':
             {'display_name': '2017 First Special Session',
@@ -72,15 +72,10 @@ metadata = dict(
              'session_id': '172X',
              '_scraped_name': '2017 Second Special Session',
              },
-        '2018':
-            {'display_name': '2018 Regular Session',
-             'session_id': '1800',
-             '_scraped_name': '2017 Regular Session',
-             },
         },
     feature_flags=['subjects', 'influenceexplorer'],
     _ignored_scraped_sessions=[
-        '2018 Regular Session',
+        '2017 Regular Session',
         '2015 Regular Session',
         '2013 Regular Session',
         '2011 Regular Session', '2010 Regular Session',

--- a/openstates/ok/__init__.py
+++ b/openstates/ok/__init__.py
@@ -20,6 +20,14 @@ class Oklahoma(Jurisdiction):
         {'name': 'Republican'},
         {'name': 'Democratic'}
     ]
+    # Sessions are named on OK's website as "{odd year} regular session" until the even year,
+    # when all data rolls over. For example, even year sessions include all odd-year-session bills.
+    # We have opted to name sessions {odd-even} Regular Session and treat them as such.
+    # - If adding a new odd-year session, add a new entry and copy the biennium pattern as above
+    # - If adding an even-year session, all you'll need to do is:
+    #   - update the `_scraped_name`
+    #   - update the session slug in the Bill scraper
+    #   - ignore the odd-year session
     legislative_sessions = [
         {
             "_scraped_name": "2012 Regular Session",

--- a/openstates/ok/__init__.py
+++ b/openstates/ok/__init__.py
@@ -47,13 +47,6 @@ class Oklahoma(Jurisdiction):
             "name": "2015-2016 Regular Session"
         },
         {
-            "_scraped_name": "2017 Regular Session",
-            "identifier": "2017-2018",
-            "name": "2017-2018 Regular Session",
-            "start_date": "2017-02-06",
-            "end_date": "2017-05-26",
-        },
-        {
             "_scraped_name": "2017 First Special Session",
             "identifier": "2017SS1",
             "name": "2017 First Special Session"
@@ -65,13 +58,14 @@ class Oklahoma(Jurisdiction):
         },
         {
             "_scraped_name": "2018 Regular Session",
-            "identifier": "2018",
-            "name": "2018 Regular Session",
-            "start_date": "2018-02-05",
+            "identifier": "2017-2018",
+            "name": "2017-2018 Regular Session",
+            "start_date": "2017-02-06",
             "end_date": "2018-05-25",
         },
     ]
     ignored_scraped_sessions = [
+        "2017 Regular Session",
         "2015 Regular Session",
         "2013 Regular Session",
         "2011 Regular Session",

--- a/openstates/ok/bills.py
+++ b/openstates/ok/bills.py
@@ -20,10 +20,9 @@ class OKBillScraper(Scraper):
         '2013SS1': '131X',
         '2013-2014': '1400',
         '2015-2016': '1600',
-        '2017-2018': '1700',
         '2017SS1': '171X',
         '2017SS2': '172X',
-        '2018': '1800',
+        '2017-2018': '1800',
     }
 
     def scrape(self, chamber=None, session=None, only_bills=None):
@@ -47,7 +46,7 @@ class OKBillScraper(Scraper):
             chamber_letter = 'H'
 
         session_id = self.meta_session_id[session]
-        self.warning(session_id)
+        self.debug("Using session slug `{}`".format(session_id))
         values = {'cbxSessionId': session_id,
                   'cbxActiveStatus': 'All',
                   'RadioButtonList1': 'On Any day',


### PR DESCRIPTION
Continuing from https://github.com/openstates/openstates/pull/2012, maintains attribution for @estaub's commits.

@jamesturk, can you sanity-check this? Runs successfully for me locally, but I don't know for sure that it won't dup or confuse anything in the database. I _think_ we're good, though ;)