### PR TITLE
ID: Fix broken version and document links

### DIFF
--- a/openstates/id/bills.py
+++ b/openstates/id/bills.py
@@ -188,7 +188,7 @@ class IDBillScraper(Scraper):
             bill.add_title(short_title, 'short title')
 
         # documents
-        doc_links = html.xpath('//div[contains(@class,"pf-content")]//a')
+        doc_links = html.xpath('//div[contains(@class,"insert-page")]//a')
         for link in doc_links:
             name = link.text_content().strip()
             href = link.get('href')


### PR DESCRIPTION
ID changed their bill page markup, so version and documents weren't getting scraped.