### PR TITLE
AR: Add 2018 fiscal session, and clean up session slug handling

### DIFF
--- a/billy_metadata/ar.py
+++ b/billy_metadata/ar.py
@@ -34,7 +34,7 @@ metadata = {
             'name': '2017-2018',
             'start_year': 2017,
             'end_year': 2018,
-            'sessions': ['2017', '2017S1'],
+            'sessions': ['2017', '2017S1', '2018F'],
         },
     ],
     'session_details': {
@@ -146,6 +146,12 @@ metadata = {
             'display_name': '2017 First Extraordinary Session',
             '_scraped_name': '2017 Special Session',
             'slug': '2017S1',
+        },
+        '2018F': {
+            'type': 'special',
+            'display_name': '2018 Fiscal Session',
+            '_scraped_name': 'Fiscal Session, 2018',
+            'slug': '2018F',
         },
     },
     'feature_flags': ['influenceexplorer', 'events'],

--- a/openstates/ar/__init__.py
+++ b/openstates/ar/__init__.py
@@ -27,7 +27,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2011",
             "classification": "primary",
             "end_date": "2011-04-27",
-            "identifier": "2011R",
+            "identifier": "2011",
             "name": "2011 Regular Session",
             "start_date": "2011-01-10"
         },
@@ -43,7 +43,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2013",
             "classification": "primary",
             "end_date": "2013-05-17",
-            "identifier": "2013R",
+            "identifier": "2013",
             "name": "2013 Regular Session",
             "start_date": "2013-01-14"
         },
@@ -59,7 +59,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2014",
             "classification": "primary",
             "end_date": "2014-03-19",
-            "identifier": "2014R",
+            "identifier": "2014",
             "name": "2014 Regular Session",
             "start_date": "2014-02-10"
         },
@@ -83,7 +83,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2015",
             "classification": "primary",
             "end_date": "2015-04-22",
-            "identifier": "2015R",
+            "identifier": "2015",
             "name": "2015 Regular Session",
             "start_date": "2015-01-12"
         },
@@ -122,7 +122,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2017",
             "classification": "primary",
             "end_date": "2017-04-22",
-            "identifier": "2017R",
+            "identifier": "2017",
             "name": "2017 Regular Session",
             "start_date": "2017-01-12"
         },

--- a/openstates/ar/__init__.py
+++ b/openstates/ar/__init__.py
@@ -27,7 +27,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2011",
             "classification": "primary",
             "end_date": "2011-04-27",
-            "identifier": "2011",
+            "identifier": "2011R",
             "name": "2011 Regular Session",
             "start_date": "2011-01-10"
         },
@@ -43,7 +43,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2013",
             "classification": "primary",
             "end_date": "2013-05-17",
-            "identifier": "2013",
+            "identifier": "2013R",
             "name": "2013 Regular Session",
             "start_date": "2013-01-14"
         },
@@ -59,7 +59,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2014",
             "classification": "primary",
             "end_date": "2014-03-19",
-            "identifier": "2014",
+            "identifier": "2014R",
             "name": "2014 Regular Session",
             "start_date": "2014-02-10"
         },
@@ -83,7 +83,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2015",
             "classification": "primary",
             "end_date": "2015-04-22",
-            "identifier": "2015",
+            "identifier": "2015R",
             "name": "2015 Regular Session",
             "start_date": "2015-01-12"
         },
@@ -122,7 +122,7 @@ class Arkansas(Jurisdiction):
             "_scraped_name": "Regular Session, 2017",
             "classification": "primary",
             "end_date": "2017-04-22",
-            "identifier": "2017",
+            "identifier": "2017R",
             "name": "2017 Regular Session",
             "start_date": "2017-01-12"
         },
@@ -133,6 +133,14 @@ class Arkansas(Jurisdiction):
             "identifier": "2017S1",
             "name": "2017 First Extraordinary Session",
             "start_date": "2017-05-01"
+        },
+        {
+            "_scraped_name": "Fiscal Session, 2018",
+            "classification": "special",
+            "end_date": "2018-03-13",
+            "identifier": "2018F",
+            "name": "2018 Fiscal Session",
+            "start_date": "2018-02-12"
         },
     ]
     ignored_scraped_sessions = [

--- a/openstates/ar/bills.py
+++ b/openstates/ar/bills.py
@@ -25,11 +25,9 @@ class ARBillScraper(Scraper):
         if not session:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
+        self.slug = session
         chambers = [chamber] if chamber else ['upper', 'lower']
         self.bills = {}
-
-        # 2017R or 2017S1
-        self.slug = session + 'R' if 'S' not in session else session
 
         for Chamber in chambers:
             yield from self.scrape_bill(Chamber, session)
@@ -73,12 +71,10 @@ class ARBillScraper(Scraper):
                 bill.add_sponsorship(primary, classification='primary',
                                      entity_type='person', primary=True)
             # ftp://www.arkleg.state.ar.us/Bills/
-            # TODO: Keep on eye on this post 2017 to see if they apply R going forward.
-            session_code = '2017R' if session == '2017' else session
 
             version_url = ("ftp://www.arkleg.state.ar.us/Bills/"
                            "%s/Public/%s.pdf" % (
-                               session_code, bill_id.replace(' ', '')))
+                               session, bill_id.replace(' ', '')))
             bill.add_version_link(bill_id, version_url, media_type='application/pdf')
 
             yield from self.scrape_bill_page(bill)

--- a/openstates/ar/bills.py
+++ b/openstates/ar/bills.py
@@ -75,7 +75,7 @@ class ARBillScraper(Scraper):
             # ftp://www.arkleg.state.ar.us/Bills/
 
             version_url = ("ftp://www.arkleg.state.ar.us/Bills/"
-                           "%s/Public/%s.pdf" % (
+                           "%s/Public/Searchable/%s.pdf" % (
                                self.slug, bill_id.replace(' ', '')))
             bill.add_version_link(bill_id, version_url, media_type='application/pdf')
 

--- a/openstates/ar/bills.py
+++ b/openstates/ar/bills.py
@@ -7,6 +7,8 @@ from pupa.scrape import Scraper, Bill, VoteEvent
 
 import lxml.html
 
+from .common import get_slug_for_session
+
 TIMEZONE = pytz.timezone('US/Central')
 
 
@@ -25,7 +27,7 @@ class ARBillScraper(Scraper):
         if not session:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
-        self.slug = session
+        self.slug = get_slug_for_session(session)
         chambers = [chamber] if chamber else ['upper', 'lower']
         self.bills = {}
 
@@ -74,7 +76,7 @@ class ARBillScraper(Scraper):
 
             version_url = ("ftp://www.arkleg.state.ar.us/Bills/"
                            "%s/Public/%s.pdf" % (
-                               session, bill_id.replace(' ', '')))
+                               self.slug, bill_id.replace(' ', '')))
             bill.add_version_link(bill_id, version_url, media_type='application/pdf')
 
             yield from self.scrape_bill_page(bill)

--- a/openstates/ar/bills.py
+++ b/openstates/ar/bills.py
@@ -1,6 +1,7 @@
 import re
 import csv
 from io import StringIO
+import urllib
 import datetime
 import pytz
 from pupa.scrape import Scraper, Bill, VoteEvent
@@ -12,13 +13,13 @@ from .common import get_slug_for_session
 TIMEZONE = pytz.timezone('US/Central')
 
 
-def unicode_csv_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
-    # csv.py doesn't do Unicode; encode temporarily as UTF-8:
-    csv_reader = csv.reader(unicode_csv_data,
-                            dialect=dialect, **kwargs)
-    for row in csv_reader:
-        # decode UTF-8 back to Unicode, cell by cell:
-        yield [cell for cell in row]
+def get_utf_16_ftp_content(url):
+    # Rough to do this within Scrapelib, as it doesn't allow custom decoding
+    raw = urllib.request.urlopen(url).read().decode('utf-16')
+    # Also, legislature may use `NUL` bytes when a cell is empty
+    NULL_BYTE_CODE = '\x00'
+    text = raw.replace(NULL_BYTE_CODE, '')
+    return text
 
 
 class ARBillScraper(Scraper):
@@ -38,9 +39,8 @@ class ARBillScraper(Scraper):
             yield bill
 
     def scrape_bill(self, chamber, session):
-        url = "ftp://www.arkleg.state.ar.us/dfadooas/LegislativeMeasures.txt"
-        page = self.get(url).text
-        page = unicode_csv_reader(StringIO(page), delimiter='|')
+        url = "ftp://www.arkleg.state.ar.us/SessionInformation/LegislativeMeasures.txt"
+        page = csv.reader(StringIO(get_utf_16_ftp_content(url)), delimiter='|')
 
         for row in page:
             bill_chamber = {'H': 'lower', 'S': 'upper'}[row[0]]
@@ -72,7 +72,6 @@ class ARBillScraper(Scraper):
             if primary:
                 bill.add_sponsorship(primary, classification='primary',
                                      entity_type='person', primary=True)
-            # ftp://www.arkleg.state.ar.us/Bills/
 
             version_url = ("ftp://www.arkleg.state.ar.us/Bills/"
                            "%s/Public/Searchable/%s.pdf" % (
@@ -84,9 +83,8 @@ class ARBillScraper(Scraper):
             self.bills[bill_id] = bill
 
     def scrape_actions(self):
-        url = "ftp://www.arkleg.state.ar.us/dfadooas/ChamberActions.txt"
-        page = self.get(url).text
-        page = csv.reader(StringIO(page))
+        url = "ftp://www.arkleg.state.ar.us/SessionInformation/ChamberActions.txt"
+        page = csv.reader(StringIO(get_utf_16_ftp_content(url)), delimiter='|')
 
         for row in page:
             bill_id = "%s%s %s" % (row[1], row[2], row[3])
@@ -94,20 +92,14 @@ class ARBillScraper(Scraper):
             if bill_id not in self.bills:
                 continue
             # different term
-            if row[-2] != self.slug:
+            if row[10] != self.slug:
                 continue
 
-            # Commas aren't escaped, but only one field (the action) can
-            # contain them so we can work around it by using both positive
-            # and negative offsets
-            bill_id = "%s%s %s" % (row[1], row[2], row[3])
-            actor = {'HU': 'lower', 'SU': 'upper'}[row[-5].upper()]
-            # manual fix for crazy time value
-            row[6] = row[6].replace('.520000000', '')
+            actor = {'H': 'lower', 'S': 'upper'}[row[7].upper()]
 
-            date = TIMEZONE.localize(datetime.datetime.strptime(row[6], "%Y-%m-%d %H:%M:%S"))
+            date = TIMEZONE.localize(datetime.datetime.strptime(row[5], "%Y-%m-%d %H:%M:%S.%f"))
             date = "{:%Y-%m-%d}".format(date)
-            action = ','.join(row[7:-5])
+            action = row[6]
 
             action_type = []
             if action.startswith('Filed'):
@@ -149,11 +141,12 @@ class ARBillScraper(Scraper):
         # It's still more efficient to get the rest of the data we're
         # interested in from the CSVs, though, because their site splits
         # other info (e.g. actions) across many pages
-        term_year = '2017'
+        session_year = int(self.slug[:4])
+        odd_year = session_year if session_year % 2 else session_year - 1
         measureno = bill.identifier.replace(" ", "")
         url = ("http://www.arkleg.state.ar.us/assembly/%s/%s/"
                "Pages/BillInformation.aspx?measureno=%s" % (
-                   term_year, self.slug, measureno))
+                   odd_year, self.slug, measureno))
         page = self.get(url).text
         bill.add_source(url)
         page = lxml.html.fromstring(page)

--- a/openstates/ar/committees.py
+++ b/openstates/ar/committees.py
@@ -20,8 +20,10 @@ class ARCommitteeScraper(Scraper):
         if session is None:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
+        session_year = int(session[:4])
+        odd_year = session_year if session_year % 2 else session_year - 1
         base_url = ("http://www.arkleg.state.ar.us/assembly/%s/%s/"
-                    "Pages/Committees.aspx?committeetype=") % (session[:4], session)
+                    "Pages/Committees.aspx?committeetype=") % (odd_year, session)
 
         for chamber, url_ext in COMM_TYPES.items():
             chamber_url = base_url + url_ext

--- a/openstates/ar/committees.py
+++ b/openstates/ar/committees.py
@@ -4,6 +4,8 @@ from pupa.scrape import Scraper, Organization
 
 import lxml.html
 
+from .common import get_slug_for_session
+
 COMM_TYPES = {'joint': 'Joint',
               'task_force': 'Task Force',
               'upper': 'Senate',
@@ -20,10 +22,11 @@ class ARCommitteeScraper(Scraper):
         if session is None:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
+        session_slug = get_slug_for_session(session)
         session_year = int(session[:4])
         odd_year = session_year if session_year % 2 else session_year - 1
         base_url = ("http://www.arkleg.state.ar.us/assembly/%s/%s/"
-                    "Pages/Committees.aspx?committeetype=") % (odd_year, session)
+                    "Pages/Committees.aspx?committeetype=") % (odd_year, session_slug)
 
         for chamber, url_ext in COMM_TYPES.items():
             chamber_url = base_url + url_ext

--- a/openstates/ar/common.py
+++ b/openstates/ar/common.py
@@ -1,0 +1,12 @@
+def get_slug_for_session(session):
+    # Session-slugs in the Arkansas LIS are the four-digit year, plus:
+    # `R` for regular session
+    # `S#` for special session, plus ordinal
+    # `F` for fiscal session (these are common in even-numbered years)
+
+    # In our `__init__.py` session metadata, we don't put an `R`
+    # after our regular-session identifiers, so need to add one here
+    if 'S' in session or session.endswith('F'):
+        return session
+    else:
+        return '{}R'.format(session)

--- a/openstates/ar/people.py
+++ b/openstates/ar/people.py
@@ -13,8 +13,11 @@ class ARLegislatorScraper(Scraper):
         if session is None:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
+
+        session_year = int(session[:4])
+        odd_year = session_year if session_year % 2 else session_year - 1
         url = ('http://www.arkleg.state.ar.us/assembly/%s/%s/Pages/'
-               'LegislatorSearchResults.aspx?member=&committee=All&chamber=') % (session[:4],
+               'LegislatorSearchResults.aspx?member=&committee=All&chamber=') % (odd_year,
                                                                                  session)
         page = self.get(url).text
         root = lxml.html.fromstring(page)

--- a/openstates/ar/people.py
+++ b/openstates/ar/people.py
@@ -3,6 +3,8 @@ import re
 from pupa.scrape import Person, Scraper
 import lxml.html
 
+from .common import get_slug_for_session
+
 
 class ARLegislatorScraper(Scraper):
     _remove_special_case = True
@@ -13,12 +15,12 @@ class ARLegislatorScraper(Scraper):
         if session is None:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
-
+        session_slug = get_slug_for_session(session)
         session_year = int(session[:4])
         odd_year = session_year if session_year % 2 else session_year - 1
         url = ('http://www.arkleg.state.ar.us/assembly/%s/%s/Pages/'
                'LegislatorSearchResults.aspx?member=&committee=All&chamber=') % (odd_year,
-                                                                                 session)
+                                                                                 session_slug)
         page = self.get(url).text
         root = lxml.html.fromstring(page)
 


### PR DESCRIPTION
Currently waiting for any `2018F` bills to show up in this CSV: ftp://www.arkleg.state.ar.us/dfadooas/LegislativeMeasures.txt

The pre-files are up on the website, but not in their CSV yet. The session begins in mid-Feb, so should be soon.

Deprecates https://github.com/openstates/openstates/pull/2069