### PR TITLE
CT: Decode sponsor names in Bills

### DIFF
--- a/openstates/ct/bills.py
+++ b/openstates/ct/bills.py
@@ -70,7 +70,7 @@ class CTBillScraper(Scraper):
             bill.add_source(info_url)
 
             for introducer in self._introducers[bill_id]:
-                bill.add_sponsorship(name=str(introducer),
+                bill.add_sponsorship(name=introducer.decode('utf-8'),
                                      classification='primary',
                                      primary=True,
                                      entity_type='person')


### PR DESCRIPTION
Addresses #2105 

Convert byte strings back to strings by decoding utf-8

Alternatively: skip encoding `name` at [L337](https://github.com/openstates/openstates/blob/5edbb75a5f99237f4589f0c5fe807878b7a6859b/openstates/ct/bills.py#L337)