### PR TITLE
LA: Add 2018 special session, and handle single-bill sessions

### DIFF
--- a/billy_metadata/la.py
+++ b/billy_metadata/la.py
@@ -45,6 +45,7 @@ metadata = {
                 '2017',
                 '2017 1st Extraordinary Session',
                 '2017 2nd Extraordinary Session',
+                '2018 1st Extraordinary Session',
                 '2018',
             ],
         },
@@ -153,6 +154,10 @@ metadata = {
         '2017 2nd Extraordinary Session': {
             'type': 'special',
             'display_name': '2017, 2nd Extraordinary Session',
+        },
+        '2018 1st Extraordinary Session': {
+            'type': 'special',
+            'display_name': '2018, 1st Extraordinary Session',
         },
         '2018': {
             'type': 'primary',

--- a/openstates/la/__init__.py
+++ b/openstates/la/__init__.py
@@ -136,6 +136,14 @@ class Louisiana(Jurisdiction):
             "end_date": "2017-06-29",
         },
         {
+            "_scraped_name": "2018 First Extraordinary Session",
+            "classification": "special",
+            "identifier": "2018 1st Extraordinary Session",
+            "name": "2018, 1st Extraordinary Session",
+            "start_date": "2018-02-19",
+            "end_date": "2018-03-07",
+        },
+        {
             "_scraped_name": "2018 Regular Session",
             "classification": "primary",
             "identifier": "2018",


### PR DESCRIPTION
@jamesturk: requires deployment of special-session-pinned task definition: https://github.com/openstates/task-definitions/commit/2f87e3dff7f61075b2fc5ad20c04762be8856943

I tested locally for both the (March's) 2018 regular session and (February's) 2018 special session, and everything scraped well.

cc https://github.com/openstates/openstates/issues/2139