### PR TITLE
fix for issue 2159

### DIFF
--- a/openstates/oh/__init__.py
+++ b/openstates/oh/__init__.py
@@ -46,14 +46,7 @@ class Ohio(Jurisdiction):
             "end_date": "2017-12-31"
         }
     ]
-    ignored_scraped_sessions = [
-        "127",
-        "126",
-        "125",
-        "124",
-        "123",
-        "122"
-    ]
+    ignored_scraped_sessions = []
 
     def get_organizations(self):
         legislature_name = "Ohio General Assembly"

--- a/openstates/oh/__init__.py
+++ b/openstates/oh/__init__.py
@@ -89,5 +89,7 @@ class Ohio(Jurisdiction):
                              '//form[@action="bill_search.cfm"]//input[@type="radio"'
                              ' and @name="SESSION"]/@value')
         # Archive does not include current session
-        sessions.append('131')
+        current_session = url_xpath("https://www.legislature.ohio.gov/legislation/search-legislation",
+                            '//div[@class="selectedValues"]/ul/span/li/text()')
+        sessions.append(current_session[0])
         return sessions

--- a/openstates/oh/__init__.py
+++ b/openstates/oh/__init__.py
@@ -85,11 +85,7 @@ class Ohio(Jurisdiction):
         yield lower
 
     def get_session_list(self):
-        sessions = url_xpath('http://archives.legislature.state.oh.us',
-                             '//form[@action="bill_search.cfm"]//input[@type="radio"'
-                             ' and @name="SESSION"]/@value')
+        sessions = url_xpath('https://www.legislature.ohio.gov/legislation/search-legislation',
+                             '//div[@class="selectedValues"]/ul/span/li/text()')
         # Archive does not include current session
-        current_session = url_xpath("https://www.legislature.ohio.gov/legislation/search-legislation",
-                            '//div[@class="selectedValues"]/ul/span/li/text()')
-        sessions.append(current_session[0])
         return sessions


### PR DESCRIPTION
Adding the current session dynamically and removing manually added current session. This fix is for Ohio scraper.

fixes #2159 