### PR TITLE
Add code to load FL house emails from their PDF directory.

### DIFF
--- a/openstates/fl/__init__.py
+++ b/openstates/fl/__init__.py
@@ -1,10 +1,13 @@
 # encoding=utf-8
+import logging
 from pupa.scrape import Jurisdiction, Organization
 from .bills import FlBillScraper
 from .people import FlPersonScraper
 from .committees import FlCommitteeScraper
 # from .events import FlEventScraper
 from openstates.utils import url_xpath
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 class Florida(Jurisdiction):

--- a/openstates/fl/people.py
+++ b/openstates/fl/people.py
@@ -9,6 +9,7 @@ from spatula import Spatula, Page
 
 log = logging.getLogger('fl')
 
+
 class SenDetail(Page):
     list_xpath = '//h4[contains(text(), "Office")]'
 

--- a/openstates/fl/people.py
+++ b/openstates/fl/people.py
@@ -88,7 +88,8 @@ class SenList(Page):
 
 class RepList(Page):
     url = "http://www.flhouse.gov/Sections/Representatives/representatives.aspx"
-    directory_pdf_url = 'http://www.myfloridahouse.gov/FileStores/Web/HouseContent/Approved/ClerksOffice/HouseDirectory.pdf'
+    directory_pdf_url = 'http://www.myfloridahouse.gov/FileStores/Web/'\
+                        'HouseContent/Approved/ClerksOffice/HouseDirectory.pdf'
     list_xpath = '//div[@id="MemberListing"]/div[@class="rep_listing1"]'
 
     def handle_page(self):
@@ -143,8 +144,8 @@ class RepList(Page):
         # deal with some stuff that ends up in name that won't work in
         # email, spaces, quotes, high latin1
         email_name = rep.name.replace('"', '')\
-                     .replace("La ", "La")\
-                     .replace("ñ", "n")
+                             .replace("La ", "La")\
+                             .replace("ñ", "n")
         (last, *other) = re.split(r'[-\s,]+', email_name)
 
         # deal with a missing nickname used in an email address
@@ -160,7 +161,7 @@ class RepList(Page):
                                        value=email,
                                        note='Capitol Office')
                 break
-            
+
         return rep
 
 

--- a/openstates/fl/people.py
+++ b/openstates/fl/people.py
@@ -152,7 +152,7 @@ class RepList(Page):
             other.append("Pat")
 
         # search through all possible first names and nicknames
-        # present - needed for some of the more
+        # present - needed for some of the more elaborate concoctions
         for first in other:
             email = '%s.%s@myfloridahouse.gov' % (first, last)
             if email in self.member_emails:

--- a/openstates/fl/people.py
+++ b/openstates/fl/people.py
@@ -1,6 +1,9 @@
 import re
+import tempfile
+import lxml
 from urllib import parse
 from pupa.scrape import Scraper, Person
+from pupa.utils import convert_pdf
 from spatula import Spatula, Page
 
 
@@ -85,7 +88,27 @@ class SenList(Page):
 
 class RepList(Page):
     url = "http://www.flhouse.gov/Sections/Representatives/representatives.aspx"
+    directory_pdf_url = 'http://www.myfloridahouse.gov/FileStores/Web/HouseContent/Approved/ClerksOffice/HouseDirectory.pdf'
     list_xpath = '//div[@id="MemberListing"]/div[@class="rep_listing1"]'
+
+    def handle_page(self):
+        self.member_emails = self._load_emails_from_directory_pdf()
+        return super(RepList, self).handle_page()
+
+    def _load_emails_from_directory_pdf(self):
+        """
+        Load the house PDF directory and convert to LXML - needed to
+        find email addresses which are gone from the website.
+        """
+        with tempfile.NamedTemporaryFile() as temp:
+            self.scraper.urlretrieve(self.directory_pdf_url, temp.name)
+            directory = lxml.etree.fromstring(convert_pdf(temp.name, 'xml'))
+
+        # pull out member email addresses from the XML salad produced
+        # above - there's no obvious way to match these to names, but
+        # fortunately they have names in them
+        return set(directory.xpath(
+            '//text[contains(text(), "@myfloridahouse.gov")]/text()'))
 
     def handle_list_item(self, item):
         link = item.xpath('.//div[contains(@class, "rep_style")]/a')[0]
@@ -112,6 +135,32 @@ class RepList(Page):
 
         self.scrape_page(RepDetail, leg_url, obj=rep)
 
+        # look for email in the list from the PDF directory - ideally
+        # we'd find a way to better index the source data which
+        # wouldn't require guessing the email, but this does at least
+        # confirm that it's correct
+
+        # deal with some stuff that ends up in name that won't work in
+        # email, spaces, quotes, high latin1
+        email_name = rep.name.replace('"', '')\
+                     .replace("La ", "La")\
+                     .replace("ñ", "n")
+        (last, *other) = re.split(r'[-\s,]+', email_name)
+
+        # deal with a missing nickname used in an email address
+        if "Patricia" in other:
+            other.append("Pat")
+
+        # search through all possible first names and nicknames
+        # present - needed for some of the more
+        for first in other:
+            email = '%s.%s@myfloridahouse.gov' % (first, last)
+            if email in self.member_emails:
+                rep.add_contact_detail(type='email',
+                                       value=email,
+                                       note='Capitol Office')
+                break
+            
         return rep
 
 


### PR DESCRIPTION
Note that if you take this PR you may also need to disable whatever is currently overriding the scraper to return some email addresses from the API (ex: FLL000150).