### PR TITLE
NY: Fix Assembly vote scraping

### DIFF
--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -274,6 +274,7 @@ class NYBillScraper(Scraper):
         elif bill_chamber == 'lower':
             assembly = AssemblyBillPage(self, session, bill, details)
             assembly.build()
+            bill = assembly.bill
 
         # A little strange the way it works out, but the Assembly
         # provides the HTML version documents and the Senate provides

--- a/openstates/ny/models.py
+++ b/openstates/ny/models.py
@@ -4,7 +4,7 @@ import re
 import inspect
 
 from itertools import islice
-  
+
 from billy.scrape.votes import Vote
 from openstates.utils import LXMLMixin
 from .utils import Urls
@@ -69,7 +69,7 @@ class AssemblyBillPage(LXMLMixin):
             pre = doc.xpath('//pre')[0].text_content().strip()
 
             no_votes = 'There are no votes for this bill in this legislative '
-                       'session.'
+            'session.'
 
             if pre == no_votes:
                 raise ValueError('No votes for this bill.')

--- a/openstates/ny/models.py
+++ b/openstates/ny/models.py
@@ -1,8 +1,12 @@
+import collections
+import datetime
 import re
 import inspect
 
+from itertools import islice
+  
+from billy.scrape.votes import Vote
 from openstates.utils import LXMLMixin
-
 from .utils import Urls
 
 
@@ -47,6 +51,69 @@ class AssemblyBillPage(LXMLMixin):
         # Collapse whitespace.
         name = re.sub('\s+', ' ', name)
         return name.strip('(), ')
+
+    def _build_sponsors_memo(self):
+        url = self.shared_url + '&Memo=Y'
+        self.bill.add_document('Sponsor\'s Memorandum', url)
+
+    def _build_lower_votes(self):
+        url = self.shared_url + '&Floor%26nbspVotes=Y'
+        self.urls.add(votes=url)
+        self.bill.add_source(url)
+        doc = self.urls.votes.doc
+        if doc is None:
+            return
+
+        # Grab bill information.
+        try:
+            pre = doc.xpath('//pre')[0].text_content().strip()
+
+            no_votes = 'There are no votes for this bill in this legislative '
+                       'session.'
+
+            if pre == no_votes:
+                raise ValueError('No votes for this bill.')
+        # Skip bill if votes can't be found.
+        except (IndexError, ValueError) as e:
+            return
+
+        actual_vote = collections.defaultdict(list)
+        for table in doc.xpath('//table'):
+
+            date = table.xpath('caption/span[contains(., "DATE:")]')
+            date = next(date[0].itersiblings()).text
+            date = datetime.datetime.strptime(date, '%m/%d/%Y')
+
+            votes = table.xpath('caption/span/span')[0].text.split(':')[1].split('/')
+            yes_count, no_count = map(int, votes)
+
+            passed = yes_count > no_count
+            vote = Vote('lower', date, 'Floor Vote', passed, yes_count,
+                        no_count, other_count=0)
+
+            tds = table.xpath('tr/td/text()')
+            votes = iter(tds)
+            while True:
+                try:
+                    data = list(islice(votes, 2))
+                    name, vote_val = data
+                except (StopIteration, ValueError):
+                    # End of data. Stop.
+                    break
+                name = self._scrub_name(name)
+
+                if vote_val.strip() == 'Y':
+                    vote.yes(name)
+                elif vote_val.strip() in ('N', 'NO'):
+                    vote.no(name)
+                else:
+                    vote.other(name)
+                    actual_vote[vote_val].append(name)
+
+            # The page doesn't provide an other_count.
+            vote['other_count'] = len(vote['other_votes'])
+            vote['actual_vote'] = actual_vote
+            self.bill.add_vote(vote)
 
     def build(self):
         '''Run all the build_* functions.

--- a/openstates/ny/models.py
+++ b/openstates/ny/models.py
@@ -38,15 +38,15 @@ class AssemblyBillPage(LXMLMixin):
             'senate': senate_url})
 
     def _scrub_name(self, name):
-        junk = [
+        junk = (re.compile(rgx) for rgx in [
             r'^Rules\s+',
             '\(2nd Vice Chairperson\)',
             '\(MS\)',
             'Assemblyman',
             'Assemblywoman',
-            'Senator']
+            'Senator'])
         for rgx in junk:
-            name = re.sub(rgx, '', name, re.I)
+            name = rgx.sub('', name, re.I)
 
         # Collapse whitespace.
         name = re.sub('\s+', ' ', name)


### PR DESCRIPTION
This is my first iteration to fix #1960. This sort of reverts [c29e88790b3f462c](https://github.com/openstates/openstates/commit/c29e88790b3f462c854539de9bc7144928ed2517#diff-c0b833d744907b858a610c3983ecd2c8L58) for `models.py`. I've tested each part of the new scraper on the interpreter, but I'm unsure about whether we need to scrape committee votes as well. As of now, this just scrapes individual floor votes.