### PR TITLE
LA Bills: Anchor elements asserted for amendments

### DIFF
--- a/openstates/la/bills.py
+++ b/openstates/la/bills.py
@@ -232,6 +232,14 @@ class LABillScraper(Scraper, LXMLMixin):
         def sbp(x): return self.scrape_bare_page(page.xpath(
             "//a[contains(text(), '%s')]" % (x))[0].attrib['href'])
 
+        def assertAnchor(anchors):
+            try:
+                for anchor in anchors:
+                    anchor.attrib['href']
+                return True
+            except KeyError:
+                return False
+
         authors = [x.text for x in sbp("Authors")]
 
         try:
@@ -246,6 +254,8 @@ class LABillScraper(Scraper, LXMLMixin):
 
         try:
             amendments = sbp("Amendments")
+            if not assertAnchor(amendments):
+                amendments = page.xpath("//a[contains(text(), 'Amendments')]")
         except IndexError:
             amendments = []
 


### PR DESCRIPTION
resolves #2222

Normally all the bills contain indirect amendment links, where we are again scraping anchor elements, and then processing.
But in bill SB292, a new amendment(FISCAL NOTE), gives the direct link, to incorporate this anomaly I have added anchor asserting function for final extracted anchor elements if they have been scraped from a pdf, they are broken, hence, we save the directly found anchor.