### PR TITLE
PA: ignore sessions from the '60's

### DIFF
--- a/openstates/pa/__init__.py
+++ b/openstates/pa/__init__.py
@@ -62,15 +62,6 @@ class Pennsylvania(Jurisdiction):
         }
     ]
     ignored_scraped_sessions = [
-        "1966 Special Session #1",
-        "1966 Regular Session",
-        "1966 Special Session #3",
-        "1965 Special Session #3",
-        "1965 Special Session #1",
-        "1964 Regular Session",
-        "1963 Special Session #1",
-        "1963 Special Session #2",
-        "1963 Regular Session",
         "1965-1966 Special Session #1",
         "1965-1966 Special Session #2",
         "1965-1966 Special Session #3",
@@ -199,6 +190,7 @@ class Pennsylvania(Jurisdiction):
         "1965 Special Session #1",
         "1965 Special Session #3",
         "1966 Special Session #1",
+        "1966 Regular Session",
         "1966 Special Session #3",
     ]
 

--- a/openstates/pa/__init__.py
+++ b/openstates/pa/__init__.py
@@ -62,6 +62,15 @@ class Pennsylvania(Jurisdiction):
         }
     ]
     ignored_scraped_sessions = [
+        "1966 Special Session #1",
+        "1966 Regular Session",
+        "1966 Special Session #3",
+        "1965 Special Session #3",
+        "1965 Special Session #1",
+        "1964 Regular Session",
+        "1963 Special Session #1",
+        "1963 Special Session #2",
+        "1963 Regular Session",
         "1965-1966 Special Session #1",
         "1965-1966 Special Session #2",
         "1965-1966 Special Session #3",


### PR DESCRIPTION
No issue yet; Bobsled will file one tonight if not approved.

Looks like they renamed some sessions; I left the old names ignored also, in case they flip back.