### PR TITLE
LA: People, Empty email skipped

### DIFF
--- a/openstates/la/people.py
+++ b/openstates/la/people.py
@@ -117,10 +117,12 @@ class LAPersonScraper(Scraper, LXMLMixin):
             '//span[@id="body_FormView5_PARTYAFFILIATIONLabel"]/text()'
             )[0].strip()
         party = party_flags[party_info]
-        email = page.xpath(
-            '//span[@id="body_FormView6_EMAILADDRESSPUBLICLabel"]/text()'
-            )[0].strip()
-
+        try:
+            email = page.xpath(
+                '//span[@id="body_FormView6_EMAILADDRESSPUBLICLabel"]/text()'
+                )[0].strip()
+        except IndexError:
+            email = None
         district = leg_info['dist'].replace('Dist', '').strip()
 
         person = Person(name=name,


### PR DESCRIPTION
resolves #2238
Email, phone is currently not available for Nicholas Muscarello(new representative of LA). Scraper was already skipping empty phone numbers, I have skipped empty emails too.
I think Website will update this info in the coming future, but I think we should get the scraper running anyway.