### PR TITLE
MD: Votes, New keyword added for matching Motion Text

### DIFF
--- a/openstates/md/bills.py
+++ b/openstates/md/bills.py
@@ -228,7 +228,8 @@ class MDBillScraper(Scraper):
             consent_calendar_bills = re.split(r'\s{2,}', lines[page_index-1].strip())
             assert consent_calendar_bills, "Could not find bills for consent calendar vote"
 
-        motion_keywords = ['favorable', 'reading', 'amendment', 'motion', 'introduced']
+        motion_keywords = ['favorable', 'reading', 'amendment', 'motion', 'introduced',
+                           'bill pass']
         motion_lines = [3, 2, 4, 5]  # Relative LineNumbers to be checked for existence of motion
 
         for i in motion_lines:

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+Education - Public School Personnel - Disciplinary


### PR DESCRIPTION
resolves #2244
Motion text on http://mgaleg.maryland.gov/2018RS/votes/Senate/1145.pdf, is poorly formatted(non- uniform with previous votes) plus the text itself is not very standard, I have added a text in motion text matching dictionary to fetch this one.