### PR TITLE
OK: People scraper fixed to continue, even if a district seat is vacant

### DIFF
--- a/openstates/ok/people.py
+++ b/openstates/ok/people.py
@@ -201,6 +201,8 @@ class OKPersonScraper(Scraper, LXMLMixin, LXMLMixinOK):
                 if match:
                     name, party = match.group(1), self._parties[match.group(2)]
                 else:
+                    self.warning("District {} appears to have empty Representative name,party"
+                                 .format(district))
                     continue
 
             url = a.get('href')

--- a/openstates/ok/people.py
+++ b/openstates/ok/people.py
@@ -198,7 +198,10 @@ class OKPersonScraper(Scraper, LXMLMixin, LXMLMixinOK):
                 continue
             else:
                 match = re.match(r'(.+) \(([A-Z])\)', a.text.strip())
-                name, party = match.group(1), self._parties[match.group(2)]
+                if match:
+                    name, party = match.group(1), self._parties[match.group(2)]
+                else:
+                    continue
 
             url = a.get('href')
 


### PR DESCRIPTION
resolves  #2249
Oklahoma's thirtieth state senate district is currently vacant. I think scraper should run anyway, hence I made fix to continue running it. 