### PR TITLE
KY: identify chamber for passed chamber actions

### DIFF
--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -217,6 +217,21 @@ class KYBillScraper(Scraper, LXMLMixin):
                 else:
                     actor = chamber
 
+                # For chamber passage,
+                # the only way to determine chamber correctly is
+                # how many total people voted on it
+                if action.startswith('3rd reading'):
+                    votes = re.search(r'(\d+)\-(\d+)', action)
+                    if votes:
+                        yeas = int(votes.groups(1)[0])
+                        nays = int(votes.groups(1)[1])
+                        # 50 is the quorum for the house,
+                        # and more than the number of senators
+                        if yeas + nays > 50:
+                            actor = 'lower'
+                        elif (yeas + nays > 20) and (yeas + nays < 50):
+                            actor = 'upper'
+
                 atype = []
                 if 'introduced in' in action:
                     atype.append('introduction')


### PR DESCRIPTION
in KY, we can correctly classify the chamber for passage actions if we count the number of votes.