### PR TITLE
MA: Updated committee rule

### DIFF
--- a/openstates/ma/actions.py
+++ b/openstates/ma/actions.py
@@ -50,7 +50,7 @@ _categorizer_rules = (
          ['amendment-passage']),
     Rule(['Amendment #\\S+ \\((?P<legislator>.+?)\\) Rejected'],
          ['amendment-failure']),
-    Rule(['referred to (?P<committees>.+)'], []),
+    Rule(['referred to (?P<committees>.+)'], ['referral-committee']),
     Rule(['Amended by'], ['amendment-passage']),
     Rule(['Committee recommended ought to pass'], ['committee-passage-favorable']),
     Rule(['Amendment #\\S+ \\((?P<legislator>.+?)\\) bundle NO rejected'],


### PR DESCRIPTION
It seems appropriate to add 'referral-committee' to the any rule that has to do with referring to committees. I've also noticed a large chunk of actions that go unclassified. Should new categories be added for larger coverage? Some example are:

Placed on file
Senate concurred
Accompanied a new draft (and several others starting with 'Accompanied')
Hearing scheduled
Reprinted as amended
Committee of conference appointed
Emergency preamble adopted

That's the majority of them. What would you think about either assigning categories to these, and creating new categories where needed? I'd be happy to help of you want to expand on this.