### PR TITLE
ND: ignore territorial assembly sessions from 1800s

### DIFF
--- a/openstates/nd/__init__.py
+++ b/openstates/nd/__init__.py
@@ -146,4 +146,6 @@ class NorthDakota(Jurisdiction):
         html = scrapelib.Scraper().get(url).text
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
-        return doc.xpath("//div[@class='view-content']//a/text()")
+        sessions = doc.xpath("//div[@class='view-content']//a/text()")
+        sessions = [session for session in sessions if 'Territorial Assembly' not in session]
+        return sessions


### PR DESCRIPTION
Resolves #2281 by removing anything with "Territorial Assembly" from the session list. 