### PR TITLE
Quell InsecureRequestWarning log messages.

### DIFF
--- a/openstates/__init__.py
+++ b/openstates/__init__.py
@@ -1,0 +1,4 @@
+import urllib3
+
+# Quell InsecureRequestWarning: Unverified HTTPS request warnings
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)


### PR DESCRIPTION
Fixes #2285, assuming we don't want to validate SSL certs.