### PR TITLE
pupa2billy: recognize became-law pupa bill action classification

### DIFF
--- a/pupa2billy/bills.py
+++ b/pupa2billy/bills.py
@@ -13,6 +13,7 @@ ACTION_MAPPING = {
     'veto-override-failure': 'bill:veto_override:failed',
     'executive-receipt': 'governor:received',
     'executive-signature': 'governor:signed',
+    'became-law': 'governor:signed',
     'executive-veto': 'governor:vetoed',
     'executive-veto-line-item': 'governor:vetoed:line-item',
     'amendment-introduction': 'amendment:introduced',


### PR DESCRIPTION
Resolves scraper run failures due to became-law action. I'll leave this PR in all day in case anyone objects, and if not merge it around COB.