### PR TITLE
AK: Fix DuplicateItemError: disambiguate pupa_id

### DIFF
--- a/openstates/ak/bills.py
+++ b/openstates/ak/bills.py
@@ -243,9 +243,12 @@ class AKBillScraper(Scraper):
         votes_text = re_vote_text.split(votes_text)
         votes_data = zip(votes_text[1::2], votes_text[2::2])
 
+        iVoteOnPage = 0
+
         # Process each.
         for motion, text in votes_data:
 
+            iVoteOnPage += 1
             yes = no = other = 0
 
             tally = re.findall(r'\b([YNEA])[A-Z]+:\s{,3}(\d{,3})', text)
@@ -262,7 +265,7 @@ class AKBillScraper(Scraper):
                 bill=bill,
                 start_date=act_date.strftime('%Y-%m-%d'),
                 chamber=act_chamber,
-                motion_text=motion,
+                motion_text=motion + ' ' + str(iVoteOnPage),
                 result='pass' if yes > no else 'fail',
                 classification='passage',
             )

--- a/openstates/ak/bills.py
+++ b/openstates/ak/bills.py
@@ -265,14 +265,15 @@ class AKBillScraper(Scraper):
                 bill=bill,
                 start_date=act_date.strftime('%Y-%m-%d'),
                 chamber=act_chamber,
-                motion_text=motion + ' ' + str(iVoteOnPage),
+                motion_text=motion,
                 result='pass' if yes > no else 'fail',
                 classification='passage',
             )
             vote.set_count('yes', yes)
             vote.set_count('no', no)
             vote.set_count('other', other)
-            vote.pupa_id = url
+
+            vote.pupa_id = (url + ' ' + str(iVoteOnPage)) if iVoteOnPage > 1 else url
 
             # In lengthy documents, the "header" can be repeated in the middle
             # of content. This regex gets rid of it.


### PR DESCRIPTION
I believe Alaska's been failing since mid-April because the vote `pupa_id` is just the journal page URL, and a page can have more than one vote on it.  I first tried just appending the motion, but it sometimes overflows the 300-character limit.  So this just keeps a vote index of the votes on a page, and appends that to the `pupa_id`.

Fixes #2254.
