### PR TITLE
NH: Include supposedly "former" members in legislature.

### DIFF
--- a/openstates/in/__init__.py
+++ b/openstates/in/__init__.py
@@ -73,6 +73,12 @@ class Indiana(Jurisdiction):
             "identifier": "2018",
             "name": "2018 Regular Session"
         },
+        # {
+        #     "_scraped_name": "Special Session 120th General Assembly (2018)",
+        #     "identifier": "2018",
+        #     "name": "2018 Special Session",
+        #     "start_date": "2018-05-14"
+        # },
     ]
     ignored_scraped_sessions = [
         "Special Session 120th General Assembly (2018)",

--- a/openstates/nh/people.py
+++ b/openstates/nh/people.py
@@ -142,8 +142,7 @@ class NHPersonScraper(Scraper, LXMLMixin):
         for chamber in chambers:
             for row in self._parse_members_txt():
                 print(row['electedStatus'])
-                if (self.chamber_map[row['LegislativeBody']] == chamber and
-                        row['electedStatus'] != 'Former'):
+                if self.chamber_map[row['LegislativeBody']] == chamber:
                     person = self._parse_person(row, chamber, seat_map)
 
                     # allow for skipping


### PR DESCRIPTION
There's no issue posted for this, but see comment https://github.com/openstates/openstates/issues/2220#issuecomment-386479706 .  

This problem is not visible in the openstates db because of another problem that I can't fix; I can see it because I've started scraping into my own DB, just so I can have access to NH data, and also perhaps because it's a new DB (so the "former" legislators aren't already in it as legacy data).

This will need to be undone when/if they start validly marking legislators as "Former".
