### PR TITLE
CA: fix adding a datetime to a bill_version breaking database import

### DIFF
--- a/openstates/ca/bills.py
+++ b/openstates/ca/bills.py
@@ -398,7 +398,7 @@ class CABillScraper(Scraper):
                     version_name,
                     version_url_pdf,
                     media_type='application/pdf',
-                    date=version_date)
+                    date=version_date.date())
 
                 # CA is inconsistent in that some bills have a short title
                 # that is longer, more descriptive than title.


### PR DESCRIPTION
Should resolve http://bobsled.openstates.org/run-CA-2018-05-11.html