### PR TITLE
MO - re-enable Senate vote scraper

### DIFF
--- a/openstates/mo/__init__.py
+++ b/openstates/mo/__init__.py
@@ -3,7 +3,7 @@ from pupa.scrape import Jurisdiction, Organization
 from openstates.utils import url_xpath
 
 from openstates.mo.bills import MOBillScraper
-# from openstates.mo.votes import MOVoteScraper
+from openstates.mo.votes import MOVoteScraper
 from openstates.mo.people import MOPersonScraper
 from openstates.mo.committees import MOCommitteeScraper
 
@@ -15,7 +15,7 @@ class Missouri(Jurisdiction):
     url = "http://www.moga.mo.gov/"
     scrapers = {
         'bills': MOBillScraper,
-        # 'votes': MOVoteScraper,
+        'votes': MOVoteScraper,
         'people': MOPersonScraper,
         'committees': MOCommitteeScraper,
     }


### PR DESCRIPTION
The MO Senate vote scraper was turned off "temporarily" in December, and no one turned it on again.  See #1992.

I've lightly verified that it seems to work.