### PR TITLE
MO: fix session assignment for special session bills

### DIFF
--- a/openstates/mo/bills.py
+++ b/openstates/mo/bills.py
@@ -611,7 +611,7 @@ class MOBillScraper(Scraper, LXMLMixin):
 
         bill_page_url = '{}/BillList.aspx?year={}&code={}'.format(
             self._house_base_url, year, code)
-        yield from self._parse_house_billpage(bill_page_url, year,)
+        yield from self._parse_house_billpage(bill_page_url, year)
 
     def scrape(self, chamber=None, session=None):
         if not session:

--- a/openstates/mo/bills.py
+++ b/openstates/mo/bills.py
@@ -29,6 +29,7 @@ class MOBillScraper(Scraper, LXMLMixin):
     # probably should work):
     _bad_urls = []
     _subjects = defaultdict(list)
+    _session_id = ''
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -160,7 +161,7 @@ class MOBillScraper(Scraper, LXMLMixin):
             bill_id,
             title=bill_desc,
             chamber='upper',
-            legislative_session=year,
+            legislative_session=self._session_id,
             classification=bill_type,
         )
         bill.subject = subs
@@ -444,7 +445,7 @@ class MOBillScraper(Scraper, LXMLMixin):
             bill_id,
             chamber='lower',
             title=bill_desc,
-            legislative_session=session,
+            legislative_session=self._session_id,
             classification=bill_type,
         )
         bill.subject = subs
@@ -610,12 +611,16 @@ class MOBillScraper(Scraper, LXMLMixin):
 
         bill_page_url = '{}/BillList.aspx?year={}&code={}'.format(
             self._house_base_url, year, code)
-        yield from self._parse_house_billpage(bill_page_url, year)
+        yield from self._parse_house_billpage(bill_page_url, year,)
 
     def scrape(self, chamber=None, session=None):
         if not session:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
+
+        # special sessions and other year manipulation messes up the session variable
+        # but we need it for correct output
+        self._session_id = session
 
         if chamber in ['upper', None]:
             yield from self._scrape_upper_chamber(session)


### PR DESCRIPTION
Due to a bug w/ how the scraper handled special sessions, MO special session bills were being output with the regular session's "identifier". This resolves that issue.