### PR TITLE
MO - temporarily re-disable Senate vote scraper till special session has votes

### DIFF
--- a/openstates/mo/__init__.py
+++ b/openstates/mo/__init__.py
@@ -3,7 +3,7 @@ from pupa.scrape import Jurisdiction, Organization
 from openstates.utils import url_xpath
 
 from openstates.mo.bills import MOBillScraper
-from openstates.mo.votes import MOVoteScraper
+# from openstates.mo.votes import MOVoteScraper
 from openstates.mo.people import MOPersonScraper
 from openstates.mo.committees import MOCommitteeScraper
 
@@ -15,7 +15,7 @@ class Missouri(Jurisdiction):
     url = "http://www.moga.mo.gov/"
     scrapers = {
         'bills': MOBillScraper,
-        'votes': MOVoteScraper,
+        # 'votes': MOVoteScraper,
         'people': MOPersonScraper,
         'committees': MOCommitteeScraper,
     }


### PR DESCRIPTION
The scraper is believed to be working correctly, but pupa errors out if a vote scraper gets no votes, and a special session just started that truly has no votes.