### PR TITLE
Add postgres with postgis to docker-compose.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,23 @@ So you can limit the scrape to Tennessee's (tn) committees and legislators using
 
   docker-compose run --rm scrape tn committees people
 
-After retrieving everything from the state, `scrape` imports the data into a Postgresql database (setup doc pending).  If you want to skip this step, include a `--scrape` modifier at the end of the command line, like so::
+After retrieving everything from the state, `scrape` imports the data into a Postgresql database. If you want to skip this step, include a `--scrape` modifier at the end of the command line, like so::
 
   docker-compose run --rm scrape tn people --scrape
 
-After you run `scrape`, it will leave .json files, one for each entity scraped, in the ``_data`` project subdirectory.  These contain the transformed, scraped data, and are very useful for debugging. 
+To import data into a postgres database, start the postgres service using docker compose::
+
+    docker-compose up postgres
+
+Then run database migrations and import jurisdictions::
+
+    docker-compose run --rm dbinit
+
+Now you can run the scrape service without the `--scrape` flag, and data will be imported into postgres. You can connect to the database and inspect data using `psql` (credentials are set in `docker-compose.yml`)::
+
+    psql postgres://postgres:secret@localhost:5432/openstates
+
+After you run `scrape`, it will leave .json files, one for each entity scraped, in the ``_data`` project subdirectory. These contain the transformed, scraped data, and are very useful for debugging. 
 
 Check out the `writing scrapers guide <http://docs.openstates.org/en/latest/contributing/getting-started.html>`_ to understand how the scrapers work & how to contribute.
 

--- a/dbinit.sh
+++ b/dbinit.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+/opt/openstates/venv-pupa/bin/pupa dbinit --country us
+
+parties="
+Democratic
+Republican
+Independent
+Progressive
+Progressive/Democratic
+Democratic/Progressive
+Democratic-Farmer-Labor
+"
+
+for party in ${parties}; do
+  /opt/openstates/venv-pupa/bin/pupa party --action add "${party}"
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
     - BILLY_MONGO_HOST=database
     - MYSQL_HOST=mysql
+    - DATABASE_URL=postgres://postgres:secret@postgres:5432/openstates
     - NEW_YORK_API_KEY
     - INDIANA_API_KEY
     - OLODATA_USERNAME
@@ -28,6 +29,20 @@ services:
     image: mongo
     ports:
     - "27017:27017"
+  postgres:
+    image: mdillon/postgis:10-alpine
+    ports:
+    - "5432:5432"
+    environment:
+    - POSTGRES_PASSWORD=secret
+    - POSTGRES_DB=openstates
+  dbinit:
+    image: openstates/openstates
+    environment:
+    - DATABASE_URL=postgres://postgres:secret@postgres:5432/openstates
+    entrypoint: /opt/openstates/venv-pupa/bin/pupa dbinit --country us
+    depends_on:
+    - postgres
   mysql:
     image: mysql
     command: mysqld --max_allowed_packet=512M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,9 @@ services:
     image: openstates/openstates
     environment:
     - DATABASE_URL=postgres://postgres:secret@postgres:5432/openstates
-    entrypoint: /opt/openstates/venv-pupa/bin/pupa dbinit --country us
+    entrypoint: /opt/openstates/openstates/dbinit.sh
+    volumes:
+    - .:/opt/openstates/openstates/
     depends_on:
     - postgres
   mysql:


### PR DESCRIPTION
Docs for importing data into postgres have been pending for a while. Here's a start: this patch adds postgres with postgis to the docker-compose config and adds the initial database migration. When I try to import data, though, pupa chokes because things like parties don't exist in the database:

```
cannot resolve pseudo id to Organization: ~{"classification": "party", "name": "Democratic"}
```

Am I missing a step for loading organizations?