### PR TITLE
IL: Allow consistent duplicate bill vote status.

### DIFF
--- a/openstates/il/bills.py
+++ b/openstates/il/bills.py
@@ -510,7 +510,8 @@ class IlBillScraper(Scraper):
             if not line.strip():
                 continue
             elif line.strip() in PASS_FAIL_WORDS:
-                if passed is not None:
+                # Crash on duplicate pass/fail status that differs from previous status
+                if passed is not None and passed != PASS_FAIL_WORDS[line.strip()]:
                     raise Exception("Duplicate pass/fail matches in [%s]" % href)
                 passed = PASS_FAIL_WORDS[line.strip()]
             elif COUNT_RE.match(line):


### PR DESCRIPTION
The IL vote parser crashes on votes with multiple vote statuses. We
probably should crash on multiple inconsistent statuses, but not when
there are duplicate statuses with the same value. This patch allows
consistent duplicate status to be processed.

For an example vote with multiple identical statuses, see
http://ilga.gov/legislation/votehistory/100/house/10000HB5231sam003_05312018_078001C.pdf.