### PR TITLE
WY: Standardize parties.

### DIFF
--- a/openstates/wy/people.py
+++ b/openstates/wy/people.py
@@ -5,7 +5,7 @@ from pupa.scrape import Scraper, Person
 
 
 class WYPersonScraper(Scraper):
-    party_map = {'R': 'republican', 'D': 'democrat', 'I': 'independent'}
+    party_map = {'R': 'Republican', 'D': 'Democratic', 'I': 'Independent'}
 
     def scrape(self, chamber=None, session=None):
         if session is None:


### PR DESCRIPTION
I was looking at #2354 and noticed that WY doesn't use the same party labels as other states. Now it will.