### PR TITLE
WY: Fix person district labels.

### DIFF
--- a/openstates/wy/people.py
+++ b/openstates/wy/people.py
@@ -45,7 +45,7 @@ class WYPersonScraper(Scraper):
 
             person = Person(
                 name=row['name'],
-                district=row['district'],
+                district=row['district'].lstrip('SH0'),
                 party=party,
                 primary_org=chamber,
                 birth_date=dob_str,


### PR DESCRIPTION
WY posts use stringified integers as district labels: "1", "2", "3",
etc. But WY people use zero-padded integers with the chamber initial:
"H01", "S02", etc. This patch strips the chamber initial and leading
zeroes from the district label for WY people so that we can import them
via pupa.