### PR TITLE
PA: Mass ignore sessions before 2000

### DIFF
--- a/openstates/pa/__init__.py
+++ b/openstates/pa/__init__.py
@@ -224,5 +224,10 @@ class Pennsylvania(Jurisdiction):
         yield lower
 
     def get_session_list(self):
+        # PA keeps slowly adding backdata, so just ignore it en masse
+        for i in range(1800, 2000):
+            self.ignored_scraped_sessions.append('{} Regular Session'.format(i))
+            self.ignored_scraped_sessions.append('{} Special Session #1'.format(i))
+
         return url_xpath('http://www.legis.state.pa.us/cfdocs/legis/home/bills/',
                          '//select[@id="billSessions"]/option/text()')


### PR DESCRIPTION
Resolves #2388 hopefully in a more scaleable way.

@jamesturk I think we talked about this (mass ignoring old PA sessions as they add backdata) in the past at some point, just flagging that i'm doing it.