### PR TITLE
Fix SD email address scraping

### DIFF
--- a/openstates/sd/people.py
+++ b/openstates/sd/people.py
@@ -10,6 +10,13 @@ class SDLegislatorScraper(Scraper):
     def scrape(self, chambers=None):
         self._committees = {}
 
+        # emails are on the contact page, fetch once and the
+        # legislator scrapers can find their emails there
+        contact_page_url = \
+                         'http://www.sdlegislature.gov/Legislators/ContactLegislator.aspx'
+        contact_page = self.get(contact_page_url).text
+        contact_page = lxml.html.fromstring(contact_page)
+
         url = 'http://www.sdlegislature.gov/Legislators/default.aspx'
         if chambers is None:
             chambers = ['upper', 'lower']
@@ -30,10 +37,10 @@ class SDLegislatorScraper(Scraper):
                 "/../span/section/table/tbody/tr/td/a"
             ):
                 name = link.text.strip()
-                yield from self.scrape_legislator(name, chamber, link.attrib['href'])
+                yield from self.scrape_legislator(name, chamber, link.attrib['href'], contact_page)
         yield from self._committees.values()
 
-    def scrape_legislator(self, name, chamber, url):
+    def scrape_legislator(self, name, chamber, url, contact_page):
         page = self.get(url).text
         page = lxml.html.fromstring(page)
         page.make_links_absolute(url)
@@ -56,10 +63,6 @@ class SDLegislatorScraper(Scraper):
         office_phone = page.xpath(
             "string(//span[contains(@id, 'CapitolPhone')])").strip()
 
-        email = None
-
-        email_link = page.xpath('//a[@id="lnkMail"]')
-
         legislator = Person(primary_org=chamber,
                             image=photo_url,
                             name=name,
@@ -69,21 +72,28 @@ class SDLegislatorScraper(Scraper):
         legislator.extras['occupation'] = occupation
         if office_phone.strip() != "":
             legislator.add_contact_detail(type='voice', value=office_phone, note='Capitol Office')
-        if email_link:
-            email = email_link[0].attrib['href'].split(":")[1]
-            legislator.add_contact_detail(type='email', value=email, note='Capitol Office')
 
-        # SD is hiding their email addresses entirely in JS now, so
-        # search through <script> blocks looking for them
-        for script in page.xpath('//script'):
-            if script.text:
-                match = re.search(r'([\w.]+@sdlegislature\.gov)', script.text)
-                if match:
+        # SD removed email from the detail pages but it's still in the
+        # contact page, shared for all congress people
+        member_id = re.search(r'Member=(\d+)', url).group(1)
+
+        # find the profile block by finding a link inside it to their
+        # detail page
+        profile_link = contact_page.xpath(
+            '//ul[@id="contact-list"]//a[contains(@href, "Member=%s")]' % (member_id,))
+        if profile_link:
+            # look for the adjacent email mailto link
+            profile_link = profile_link[0]
+            profile_block = profile_link.getparent().getparent().getparent()
+            email_link = profile_block.xpath('./span/span/a[@class="mail-break"]')
+            if email_link:
+                email = email_link[0].text
+                email = email.lstrip()
+                email = email.rstrip()
+                if email:
                     legislator.add_contact_detail(type='email',
-                                                  value=match.group(0),
+                                                  value=email,
                                                   note='Capitol Office')
-                    break
-
         home_address = [
                 x.strip() for x in
                 page.xpath('//td/span[contains(@id, "HomeAddress")]/text()')

--- a/openstates/sd/people.py
+++ b/openstates/sd/people.py
@@ -13,7 +13,7 @@ class SDLegislatorScraper(Scraper):
         # emails are on the contact page, fetch once and the
         # legislator scrapers can find their emails there
         contact_page_url = \
-                         'http://www.sdlegislature.gov/Legislators/ContactLegislator.aspx'
+            'http://www.sdlegislature.gov/Legislators/ContactLegislator.aspx'
         contact_page = self.get(contact_page_url).text
         contact_page = lxml.html.fromstring(contact_page)
 


### PR DESCRIPTION
SD has removed email addresses from detail pages, fetch them from the Contact Legislators page instead.  Fixes issue 2414.