### PR TITLE
Tim/2018/ny window

### DIFF
--- a/openstates/ny/apiclient.py
+++ b/openstates/ny/apiclient.py
@@ -45,7 +45,7 @@ class OpenLegislationAPIClient(object):
     Client for interfacing with the NY Senate's Open Legislation API.
     http://legislation.nysenate.gov/static/docs/html/index.html
     """
-    root = 'http://legislation.nysenate.gov/api/3/'
+    root = 'https://legislation.nysenate.gov/api/3/'
     resources = dict(
         bills=(
             'bills/{session_year}?limit={limit}&offset={offset}&full={full}'

--- a/openstates/ny/apiclient.py
+++ b/openstates/ny/apiclient.py
@@ -53,7 +53,7 @@ class OpenLegislationAPIClient(object):
             'bills/{session_year}/{bill_id}?summary={summary}&detail='
             '{detail}'),
         bill_updates='bills/{session_year}/{bill_id}/updates?',
-        updated_bills='bills/updates/{from_datetime}/{to_datetime}?',
+        updated_bills='bills/updates/{from_datetime}/{to_datetime}?summary={summary}&detail={detail}&limit={limit}&offset={offset}',
         committees=(
             'committees/{session_year}/{chamber}?full={full}'),
         committee='committees/{session_year}/{chamber}/{committee_name}?',

--- a/openstates/ny/apiclient.py
+++ b/openstates/ny/apiclient.py
@@ -11,6 +11,7 @@ class BadAPIResponse(Exception):
     Raised if the service returns a service code higher than 400,
     other than 429. Makes the response object avaible as exc.resp.
     """
+
     def __init__(self, resp, *args):
         super(BadAPIResponse, self).__init__(self, *args)
         self.resp = resp
@@ -104,7 +105,8 @@ class OpenLegislationAPIClient(object):
         tries = 0
         while response is None and tries < num_bad_packets_allowed:
             try:
-                response = self.scraper.get(url, *requests_args, **requests_kwargs)
+                response = self.scraper.get(
+                    url, *requests_args, **requests_kwargs)
             except SysCallError as e:
                 err, string = e.args
                 if err != 104:
@@ -112,7 +114,8 @@ class OpenLegislationAPIClient(object):
                 tries += 1
                 if tries >= num_bad_packets_allowed:
                     print(err, string)
-                    raise RuntimeError('Received too many bad packets from API.')
+                    raise RuntimeError(
+                        'Received too many bad packets from API.')
 
         return response
 
@@ -143,5 +146,6 @@ class OpenLegislationAPIClient(object):
         experience.'
         """
         seconds = int(resp.headers['retry-after'])
-        self.scraper.info('Got a 429: Sleeping %s seconds per retry-after header.' % seconds)
+        self.scraper.info(
+            'Got a 429: Sleeping %s seconds per retry-after header.' % seconds)
         time.sleep(seconds)

--- a/openstates/ny/apiclient.py
+++ b/openstates/ny/apiclient.py
@@ -54,7 +54,8 @@ class OpenLegislationAPIClient(object):
             'bills/{session_year}/{bill_id}?summary={summary}&detail='
             '{detail}'),
         bill_updates='bills/{session_year}/{bill_id}/updates?',
-        updated_bills='bills/updates/{from_datetime}/{to_datetime}?summary={summary}&detail={detail}&limit={limit}&offset={offset}',
+        updated_bills='bills/updates/{from_datetime}/{to_datetime}'
+        '?summary={summary}&detail={detail}&limit={limit}&offset={offset}',
         committees=(
             'committees/{session_year}/{chamber}?full={full}'),
         committee='committees/{session_year}/{chamber}/{committee_name}?',

--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -368,5 +368,6 @@ class NYBillScraper(Scraper):
             if bill_no:
                 if bill['printNo'] == bill_no:
                     yield from self._scrape_bill(session, bill)
+                    return
             else:
                 yield from self._scrape_bill(session, bill)

--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -74,7 +74,8 @@ class NYBillScraper(Scraper):
                 title, (prefix, number, active_version))
 
     def _parse_senate_votes(self, vote_data, bill, url):
-        vote_datetime = datetime.datetime.strptime(vote_data['voteDate'], '%Y-%m-%d')
+        vote_datetime = datetime.datetime.strptime(
+            vote_data['voteDate'], '%Y-%m-%d')
 
         if vote_data['voteType'] == 'FLOOR':
             motion = 'Floor Vote'
@@ -157,7 +158,8 @@ class NYBillScraper(Scraper):
                 # set detail=True to see what changed on the bill
                 response = self.api_client.get(
                     'updated_bills',
-                    from_datetime=from_datetime.replace(microsecond=0).isoformat(),
+                    from_datetime=from_datetime.replace(
+                        microsecond=0).isoformat(),
                     to_datetime=to_datetime.replace(microsecond=0).isoformat(),
                     detail=False,
                     summary=True,
@@ -165,7 +167,8 @@ class NYBillScraper(Scraper):
                     offset=offset,
                     type='updated')
 
-                self.info("{} bills updated since {}".format(response['total'], from_datetime.replace(microsecond=0).isoformat()))
+                self.info("{} bills updated since {}".format(
+                    response['total'], from_datetime.replace(microsecond=0).isoformat()))
             else:
                 response = self.api_client.get(
                     'bills', session_year=start_year,
@@ -183,11 +186,11 @@ class NYBillScraper(Scraper):
                     # unfortunately the updated bills since N api doesn't offer
                     # the full bill info, so get them individually
                     resp = self.api_client.get('bill',
-                        session_year=bill['item']['session'],
-                        bill_id=bill['item']['printNo'],
-                        summary=False,
-                        detail=True,
-                    )
+                                               session_year=bill['item']['session'],
+                                               bill_id=bill['item']['printNo'],
+                                               summary=False,
+                                               detail=True,
+                                               )
                     bill = resp['result']
                 yield bill
 
@@ -265,7 +268,8 @@ class NYBillScraper(Scraper):
 
         for action in bill_data['actions']['items']:
             chamber = chamber_map[action['chamber'].lower()]
-            action_datetime = datetime.datetime.strptime(action['date'], '%Y-%m-%d')
+            action_datetime = datetime.datetime.strptime(
+                action['date'], '%Y-%m-%d')
             action_date = action_datetime.date()
             types, _ = NYBillScraper.categorizer.categorize(action['text'])
 
@@ -334,7 +338,8 @@ class NYBillScraper(Scraper):
         yield bill
 
     def parse_relative_time(self, time_str):
-        regex = re.compile(r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+        regex = re.compile(
+            r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
         parts = regex.match(time_str)
         if not parts:
             return
@@ -345,12 +350,11 @@ class NYBillScraper(Scraper):
                 time_params[name] = int(param)
         return datetime.timedelta(**time_params)
 
-
     # This scrape supports both windowed scraping for
     # bills updated since a datetime, and individual bill scraping
     # NEW_YORK_API_KEY=key pupa update ny bills --scrape bill_no=S155
     # or
-    # EW_YORK_API_KEY=key pupa update ny bills --scrape window=5d1h
+    # NEW_YORK_API_KEY=key pupa update ny bills --scrape window=5d1h
     def scrape(self, session=None, bill_no=None, window=None):
         self.api_client = OpenLegislationAPIClient(self)
 


### PR DESCRIPTION
State:NY 

Move the API over to https endpoints, and allow the scraper to take bill_no= and window= arguments, to scrape a single bill, or all bills updated in the last <window>.

Window is of the format ```<int>d<int>h<int>m<int>s``` which are all optional, so 
```NEW_YORK_API_KEY=key pupa update ny bills --scrape window=5d1h```
gets you everything with changes in the past 5 days, 1 hour. 

Note: due to how the API returns data, fetching with window= requires fetching all the bills from the api individually instead of in bulk. This is still **hours** faster for most scrapes, but there's probably some break-even point where if you request hundreds of days it would be slower than just doing a full scrape. 

bill_no is without spaces:
```NEW_YORK_API_KEY=key pupa update ny bills --scrape bill_no=S155```
