### PR TITLE
OH: Concatenate bill and vote ids to avoid collisions.

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -423,7 +423,8 @@ class OHBillScraper(Scraper):
                                  classification='passed',
                                  bill=bill
                                  )
-            vote.pupa_id = str(v['revno'])
+            # Concatenate the bill identifier and vote identifier to avoid collisions
+            vote.pupa_id = '{}:{}'.format(bill.identifier.replace(' ', ''), v['revno'])
             # the yea and nay counts are not displayed, but vote totals are
             # and passage status is.
             yes_count = 0


### PR DESCRIPTION
If we go this route, I think we'll want to reimport existing OH votes to avoid duplicates.

[Fixes #2327]