### PR TITLE
Adjust text for scraping DE legislator addresses

### DIFF
--- a/openstates/de/people.py
+++ b/openstates/de/people.py
@@ -65,7 +65,7 @@ class DEPersonScraper(Scraper, LXMLMixin):
                                 )[0].text_content().strip()
             if label.text == 'Email Address:':
                 email = value
-            elif label.text == 'Legislative Address:':
+            elif label.text == 'Legislative Office:':
                 address = re.sub('\s+', ' ', value).strip()
             elif label.text == 'Legislative Phone:':
                 phone = value


### PR DESCRIPTION
The text on a DE legislator's page that indicates their address is now "Legislative Office" instead of "Legislative Address". For example, see: https://legis.delaware.gov/LegislatorDetail?personId=133.