### PR TITLE
Update contact info scraping for DC legislators

### DIFF
--- a/openstates/dc/people.py
+++ b/openstates/dc/people.py
@@ -79,12 +79,12 @@ class DCPersonScraper(Scraper):
 
             if office_address:
                 person.add_contact_detail(type='address', value=office_address,
-                                          note='District Office')
+                                          note='Capitol Office')
             if phone:
                 person.add_contact_detail(type='voice', value=phone,
-                                          note='District Office')
-            if phone:
-                person.add_contact_detail(type='voice', value=phone,
+                                          note='Capitol Office')
+            if fax:
+                person.add_contact_detail(type='fax', value=fax,
                                           note='Capitol Office')
             if email:
                 person.add_contact_detail(type='email', value=email,


### PR DESCRIPTION
We previously added the office address scraped for DC legislators as the address of their district office, but these offices are really their capitol offices. We also scraped but didn't add their fax information as a contact detail. We now add their fax information correctly, and interpret all information as being about their capitol office.