### PR TITLE
MD: Don't include phone numbers in address

### DIFF
--- a/openstates/md/people.py
+++ b/openstates/md/people.py
@@ -49,7 +49,7 @@ class MDPersonScraper(Scraper):
             for line in addr_lines:
                 if 'Phone:' in line:
                     phone = re.findall('Phone: (\d{3}-\d{3}-\d{4})', line)[0]
-                if 'Fax:' in line:
+                elif 'Fax:' in line:
                     # Number oddities: one has two dashes, one has a dash and then a space.
                     line = line.replace('--', '-').replace('- ', '-')
                     fax = re.findall('Fax: (\d{3}-\d{3}-\d{4})', line)[0]


### PR DESCRIPTION
I accidentially forgot to use an elif in #2460, so when a phone number was included in the address field, it would be parsed and included in the parsed address as well. Clean it up by only adding it to the parsed address if it's not a fax line or a phone line.