### PR TITLE
Tim/2019/ky prefiles

### DIFF
--- a/billy_metadata/fl.py
+++ b/billy_metadata/fl.py
@@ -35,6 +35,12 @@ metadata = {
             'end_year': 2018,
             'sessions': ['2017', '2017A', '2018'],
         },
+        {
+            'name': '2019-2020',
+            'start_year': 2019,
+            'end_year': 2020,
+            'sessions': ['2019'],
+        },
     ],
     'session_details': {
         '2011': {
@@ -142,6 +148,10 @@ metadata = {
         '2018': {
             'type': 'primary',
             'display_name': '2018 Regular Session',
+        },
+        '2019': {
+            'type': 'primary',
+            'display_name': '2019 Regular Session',
         },
     },
     'feature_flags': ['events', 'influenceexplorer'],

--- a/openstates/fl/__init__.py
+++ b/openstates/fl/__init__.py
@@ -52,9 +52,11 @@ class Florida(Jurisdiction):
             'identifier': '2017A', 'classification': 'special'},
         {'name': '2018 Regular Session', 'identifier': '2018', 'classification': 'primary',
          'start_date': '2018-01-08', 'end_date': '2018-03-09'},
+        {'name': '2019 Regular Session', 'identifier': '2019', 'classification': 'primary',
+         'start_date': '2019-03-05'},
     ]
     ignored_scraped_sessions = ['2010',
-                                '2010A', '2010O', '2012O', '2016O', '2014O', '2018', '2019']
+                                '2010A', '2010O', '2012O', '2016O', '2014O', '2018']
 
     def get_organizations(self):
         legis = Organization(name="Florida Legislature",

--- a/openstates/fl/bills.py
+++ b/openstates/fl/bills.py
@@ -63,7 +63,7 @@ class BillList(Page):
 
         sponsor = re.sub(r'^(?:Rep|Sen)\.\s', "", sponsor)
         for sp in sponsor.split(', '):
-            bill.add_sponsorship(sp, 'primary', 'person', True)
+            bill.add_sponsorship(sp.strip(), 'primary', 'person', True)
 
         yield from self.scrape_page_items(BillDetail, url=bill_url, obj=bill)
 
@@ -398,6 +398,7 @@ class HousePage(Page):
         # Keep the digits and all following characters in the bill's ID
         bill_number = re.search(r'^\w+\s(\d+\w*)$', self.kwargs['bill'].identifier).group(1)
         session_number = {
+            '2019': '87',
             '2018': '86',
             '2017A': '85',
             '2017': '83',

--- a/openstates/ky/__init__.py
+++ b/openstates/ky/__init__.py
@@ -101,6 +101,13 @@ class Kentucky(Jurisdiction):
             "start_date": "2017-01-03"
         },
         {
+            "_scraped_name": "2019 Regular Session",
+            "classification": "primary",
+            "identifier": "2019RS",
+            "name": "2019 Regular Session",
+            "start_date": "2019-01-08"
+        },
+        {
             "_scraped_name": "2018 Regular Session",
             "classification": "primary",
             "end_date": "2018-04-13",

--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -99,11 +99,11 @@ class KYBillScraper(Scraper, LXMLMixin):
         bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_bills.htm'.format(
             abbr)
         if 'upper' == chamber:
-            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_senate.htm'.format(
-                abbr)
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_senate.htm' \
+                .format(abbr)
         elif 'lower' == chamber:
-            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_house.htm'.format(
-                abbr)
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_house.htm' \
+                .format(abbr)
 
         yield from self.scrape_bill_list(chamber, session, bill_url, prefile=True)
 

--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -114,7 +114,7 @@ class KYBillScraper(Scraper, LXMLMixin):
         version_link_node = self.get_node(
             page,
             '//a[contains(@href, "{bill_id}/bill.doc") or contains(@href,'
-            '"{bill_id}/bill.pdf")]'.format(bill_id=short_bill_id))
+            '"{bill_id}/bill.pdf")]'.format(bill_id=short_bill_id.replace('*', '')))
 
         if version_link_node is None:
             # Bill withdrawn

--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -40,7 +40,7 @@ class KYBillScraper(Scraper, LXMLMixin):
                 for bill in sdoc.xpath('//div[@id="bul"]/a/text()'):
                     self._subjects[bill.replace(' ', '')].append(subject)
 
-    def scrape(self, session=None, chamber=None, prefile=None):
+    def scrape(self, session=None, chamber=None, prefile=False):
         if not session:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
@@ -63,7 +63,7 @@ class KYBillScraper(Scraper, LXMLMixin):
             for chamber in chambers:
                 yield from self.scrape_session(chamber, session, prefile)
 
-    def scrape_session(self, chamber, session, prefile=None):
+    def scrape_session(self, chamber, session, prefile=False):
         if prefile:
             yield from self.scrape_prefile_list(chamber, session)
         else:
@@ -75,7 +75,7 @@ class KYBillScraper(Scraper, LXMLMixin):
                 chamber_abbr(chamber))
             yield from self.scrape_bill_list(chamber, session, resolution_url)
 
-    def scrape_bill_list(self, chamber, session, url, prefile=None):
+    def scrape_bill_list(self, chamber, session, url, prefile=False):
         bill_abbr = None
         page = self.lxmlize(url)
 
@@ -107,7 +107,7 @@ class KYBillScraper(Scraper, LXMLMixin):
 
         yield from self.scrape_bill_list(chamber, session, bill_url, prefile=True)
 
-    def parse_bill(self, chamber, session, bill_id, url, prefile=None):
+    def parse_bill(self, chamber, session, bill_id, url, prefile=False):
         page = self.lxmlize(url)
 
         short_bill_id = re.sub(r'(H|S)([JC])R', r'\1\2', bill_id)

--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -40,7 +40,7 @@ class KYBillScraper(Scraper, LXMLMixin):
                 for bill in sdoc.xpath('//div[@id="bul"]/a/text()'):
                     self._subjects[bill.replace(' ', '')].append(subject)
 
-    def scrape(self, session=None, chamber=None):
+    def scrape(self, session=None, chamber=None, prefile=None):
         if not session:
             session = self.latest_session()
             self.info('no session specified, using %s', session)
@@ -49,20 +49,32 @@ class KYBillScraper(Scraper, LXMLMixin):
         if int(session[0:4]) >= 2016:
             self._is_post_2016 = True
 
-        self.scrape_subjects(session)
         chambers = [chamber] if chamber else ['upper', 'lower']
-        for chamber in chambers:
-            yield from self.scrape_session(chamber, session)
 
-    def scrape_session(self, chamber, session):
-        bill_url = session_url(session) + "bills_%s.htm" % chamber_abbr(chamber)
-        yield from self.scrape_bill_list(chamber, session, bill_url)
+        # KY lists prefiles on a seperate page
+        # So enable them via CLI arg, eg:
+        # pupa update ky bills --scrape prefile=True session=2019RS
+        # make sure to set the session explicitly if you do this.
+        if prefile:
+            for chamber in chambers:
+                yield from self.scrape_session(chamber, session, prefile)
+        else:
+            self.scrape_subjects(session)
+            for chamber in chambers:
+                yield from self.scrape_session(chamber, session, prefile)
 
-        resolution_url = session_url(session) + "res_%s.htm" % (
-            chamber_abbr(chamber))
-        yield from self.scrape_bill_list(chamber, session, resolution_url)
+    def scrape_session(self, chamber, session, prefile=None):
+        if prefile:
+            yield from self.scrape_prefile_list(chamber, session)
+        else:
+            bill_url = session_url(session) + "bills_%s.htm" % chamber_abbr(chamber)
+            yield from self.scrape_bill_list(chamber, session, bill_url)
 
-    def scrape_bill_list(self, chamber, session, url):
+            resolution_url = session_url(session) + "res_%s.htm" % (
+                chamber_abbr(chamber))
+            yield from self.scrape_bill_list(chamber, session, resolution_url)
+
+    def scrape_bill_list(self, chamber, session, url, prefile=None):
         bill_abbr = None
         page = self.lxmlize(url)
 
@@ -77,9 +89,23 @@ class KYBillScraper(Scraper, LXMLMixin):
                 else:
                     bill_id = bill_abbr + bill_id
 
-                yield from self.parse_bill(chamber, session, bill_id, link.attrib['href'])
+                yield from self.parse_bill(chamber, session, bill_id, link.attrib['href'], prefile)
 
-    def parse_bill(self, chamber, session, bill_id, url):
+
+    def scrape_prefile_list(self, chamber, session):
+        # convert 2019RS to 19RS
+        abbr = session.replace('20', '')
+
+        bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_bills.htm'.format(abbr)
+        if 'upper' == chamber:
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_senate.htm'.format(abbr)
+        elif 'lower' == chamber:
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_house.htm'.format(abbr)
+
+        yield from self.scrape_bill_list(chamber, session, bill_url, prefile=True)
+
+
+    def parse_bill(self, chamber, session, bill_id, url, prefile=None):
         page = self.lxmlize(url)
 
         short_bill_id = re.sub(r'(H|S)([JC])R', r'\1\2', bill_id)
@@ -90,8 +116,12 @@ class KYBillScraper(Scraper, LXMLMixin):
 
         if version_link_node is None:
             # Bill withdrawn
-            self.logger.warning('Bill withdrawn.')
-            return
+            if prefile:
+                source_url = None
+            else:
+                self.logger.warning('Bill withdrawn.')
+                return
+
         else:
             source_url = version_link_node.attrib['href']
 
@@ -107,6 +137,10 @@ class KYBillScraper(Scraper, LXMLMixin):
             title_texts = list(filter(None, [text.strip() for text in title_texts]))
             title_texts = [s for s in title_texts if s != ',' and not s.startswith('(BR ')]
             title = ' '.join(title_texts)
+
+            # strip opening '- ' which occurs on some bills
+            if title.startswith('- '):
+                title = title[len('- '):]
 
             actions = self.get_nodes(
                 page,
@@ -146,7 +180,8 @@ class KYBillScraper(Scraper, LXMLMixin):
         bill.subject = self._subjects[bill_id]
         bill.add_source(url)
 
-        bill.add_version_link("Most Recent Version", source_url, media_type=mimetype)
+        if source_url:
+            bill.add_version_link("Most Recent Version", source_url, media_type=mimetype)
 
         other_versions = page.xpath('//a[contains(@href, "/recorddocuments/bill/") and'
                                     ' not(contains(@href, "/bill.pdf")) and'
@@ -237,6 +272,8 @@ class KYBillScraper(Scraper, LXMLMixin):
                     atype.append('introduction')
                     if 'to ' in action:
                         atype.append('referral-committee')
+                elif 'Prefiled by' in action:
+                    atype.append('filing')
                 elif 'signed by Governor' in action:
                     atype.append('executive-signature')
                 elif 'vetoed' in action:

--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -67,7 +67,8 @@ class KYBillScraper(Scraper, LXMLMixin):
         if prefile:
             yield from self.scrape_prefile_list(chamber, session)
         else:
-            bill_url = session_url(session) + "bills_%s.htm" % chamber_abbr(chamber)
+            bill_url = session_url(session) + \
+                "bills_%s.htm" % chamber_abbr(chamber)
             yield from self.scrape_bill_list(chamber, session, bill_url)
 
             resolution_url = session_url(session) + "res_%s.htm" % (
@@ -91,19 +92,20 @@ class KYBillScraper(Scraper, LXMLMixin):
 
                 yield from self.parse_bill(chamber, session, bill_id, link.attrib['href'], prefile)
 
-
     def scrape_prefile_list(self, chamber, session):
         # convert 2019RS to 19RS
         abbr = session.replace('20', '')
 
-        bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_bills.htm'.format(abbr)
+        bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_bills.htm'.format(
+            abbr)
         if 'upper' == chamber:
-            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_senate.htm'.format(abbr)
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_senate.htm'.format(
+                abbr)
         elif 'lower' == chamber:
-            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_house.htm'.format(abbr)
+            bill_url = 'http://www.lrc.ky.gov/record/{}/prefiled/prefiled_sponsor_house.htm'.format(
+                abbr)
 
         yield from self.scrape_bill_list(chamber, session, bill_url, prefile=True)
-
 
     def parse_bill(self, chamber, session, bill_id, url, prefile=None):
         page = self.lxmlize(url)
@@ -134,8 +136,10 @@ class KYBillScraper(Scraper, LXMLMixin):
             title_texts = self.get_nodes(
                 page,
                 '//div[@class="StandardText leftDivMargin"]/text()')
-            title_texts = list(filter(None, [text.strip() for text in title_texts]))
-            title_texts = [s for s in title_texts if s != ',' and not s.startswith('(BR ')]
+            title_texts = list(
+                filter(None, [text.strip() for text in title_texts]))
+            title_texts = [s for s in title_texts if s !=
+                           ',' and not s.startswith('(BR ')]
             title = ' '.join(title_texts)
 
             # strip opening '- ' which occurs on some bills
@@ -155,7 +159,8 @@ class KYBillScraper(Scraper, LXMLMixin):
             else:
                 title = pars[0].getprevious().tail
                 if not title:
-                    self.warning('walking backwards to get bill title, error prone!')
+                    self.warning(
+                        'walking backwards to get bill title, error prone!')
                     title = pars[0].getprevious().getprevious()
                     while not title.tail:
                         title = title.getprevious()
@@ -181,7 +186,8 @@ class KYBillScraper(Scraper, LXMLMixin):
         bill.add_source(url)
 
         if source_url:
-            bill.add_version_link("Most Recent Version", source_url, media_type=mimetype)
+            bill.add_version_link("Most Recent Version",
+                                  source_url, media_type=mimetype)
 
         other_versions = page.xpath('//a[contains(@href, "/recorddocuments/bill/") and'
                                     ' not(contains(@href, "/bill.pdf")) and'
@@ -196,7 +202,8 @@ class KYBillScraper(Scraper, LXMLMixin):
                 mimetype = 'application/pdf'
 
             version_title = version_link.xpath('text()')[0]
-            bill.add_version_link(version_title, source_url, media_type=mimetype)
+            bill.add_version_link(
+                version_title, source_url, media_type=mimetype)
 
         # LM is "Locally Mandated fiscal impact"
         fiscal_notes = page.xpath('//a[contains(@href, "/LM.pdf")]')
@@ -207,7 +214,8 @@ class KYBillScraper(Scraper, LXMLMixin):
             elif source_url.endswith('.pdf'):
                 mimetype = 'application/pdf'
 
-            bill.add_document_link("Fiscal Note", source_url, media_type=mimetype)
+            bill.add_document_link(
+                "Fiscal Note", source_url, media_type=mimetype)
 
         for link in page.xpath("//a[contains(@href, 'legislator/')]"):
             bill.add_sponsorship(link.text.strip(), classification='primary',
@@ -225,7 +233,8 @@ class KYBillScraper(Scraper, LXMLMixin):
                 if self._is_post_2016:
                     action_date_string = action_date_text.replace(',', '')
                 else:
-                    action_date_string = '{} {}'.format(action_date_text, session[0:4])
+                    action_date_string = '{} {}'.format(
+                        action_date_text, session[0:4])
 
                 # This patch is super hacky, but allows us to better
                 # capture actions that screw up the formatting such as
@@ -325,11 +334,13 @@ class KYBillScraper(Scraper, LXMLMixin):
                 # lowercases all other letters.
                 action = (action[0].upper() + action[1:])
 
-                action_date = timezone('America/Kentucky/Louisville').localize(action_date)
+                action_date = timezone(
+                    'America/Kentucky/Louisville').localize(action_date)
                 action_date = action_date.strftime('%Y-%m-%d')
 
                 if action:
-                    bill.add_action(action, action_date, chamber=actor, classification=atype)
+                    bill.add_action(action, action_date,
+                                    chamber=actor, classification=atype)
 
         try:
             votes_link = page.xpath(
@@ -351,7 +362,8 @@ class KYBillScraper(Scraper, LXMLMixin):
                 break
             for action in bill.actions[:i]:
                 if action['date'] > intro_date:
-                    action['date'] = action['date'].replace(year=action['date'].year-1)
+                    action['date'] = action['date'].replace(
+                        year=action['date'].year-1)
                     self.debug('corrected year for %s', action['action'])
 
         yield bill


### PR DESCRIPTION
KY is a state that has its prefiles up on seperate pages and doesn't assign them true bill numbers yet.

Re-reading https://github.com/openstates/openstates/pull/1146 and https://github.com/openstates/openstates/issues/1205 -- I put prefiles behind a pupa argument, so that you have to pull them explicitly. I also made it so 2019 isn't the default session, since otherwise running scrape fl would throw an error.

My proposed syntax:
```
pupa update fl bills --scrape session=2019RS prefile=True
```

Any objections? I won't merge this one until ok'd.