### PR TITLE
KS: Fail on bill scrape errors.

### DIFF
--- a/openstates/ks/bills.py
+++ b/openstates/ks/bills.py
@@ -2,7 +2,6 @@ import re
 import json
 import datetime
 
-import scrapelib
 import lxml.html
 from pupa.scrape import Scraper, Bill, VoteEvent
 
@@ -109,11 +108,7 @@ class KSBillScraper(Scraper):
             # Versions are exposed in `bill_data['versions'],
             # but lack any descriptive text or identifiers;
             # continue to scrape these from the HTML
-            try:
-                yield from self.scrape_html(bill, session)
-            except scrapelib.HTTPError as e:
-                self.warning('unable to fetch HTML for bill {0}'.format(
-                    bill['bill_id']))
+            yield from self.scrape_html(bill, session)
 
             yield bill
 


### PR DESCRIPTION
I was going to fix the `KeyError` in the `except` block here, but taking a closer look, I'm not sure why we're ignoring scrape errors in the first place. I'm running the scraper now to see if this introduces any new problems.