### PR TITLE
*.state.tx.us -> *.texas.gov 

### DIFF
--- a/billy_metadata/tx.py
+++ b/billy_metadata/tx.py
@@ -5,7 +5,7 @@ metadata = {
     'abbreviation': 'tx',
     'capitol_timezone': 'America/Chicago',
     'legislature_name': 'Texas Legislature',
-    'legislature_url': 'http://www.capitol.state.tx.us/',
+    'legislature_url': 'https://capitol.texas.gov/',
     'chambers': {
         'upper': {'name': 'Senate', 'title': 'Senator'},
         'lower': {'name': 'House', 'title': 'Representative'},

--- a/openstates/tx/__init__.py
+++ b/openstates/tx/__init__.py
@@ -12,7 +12,7 @@ class Texas(Jurisdiction):
     division_id = "ocd-division/country:us/state:tx"
     classification = "government"
     name = "Texas"
-    url = "http://www.capitol.state.tx.us/"
+    url = "https://capitol.texas.gov/"
     scrapers = {
         'people': TXPersonScraper,
         'committees': TXCommitteeScraper,
@@ -143,7 +143,7 @@ class Texas(Jurisdiction):
     ]
 
     def get_session_list(self):
-        return url_xpath('http://www.legis.state.tx.us/',
+        return url_xpath('https://capitol.texas.gov/',
                          '//select[@name="cboLegSess"]/option/text()')
 
     def get_organizations(self):

--- a/openstates/tx/bills.py
+++ b/openstates/tx/bills.py
@@ -21,7 +21,7 @@ class TXBillScraper(Scraper, LXMLMixin):
         'F': 'Enrolled'
     }
     companion_url = (
-        'http://www.legis.state.tx.us/BillLookup/Companions.aspx'
+        'https://capitol.texas.gov/BillLookup/Companions.aspx'
         '?LegSess={}&Bill={}'
     )
 

--- a/openstates/tx/committees.py
+++ b/openstates/tx/committees.py
@@ -15,9 +15,9 @@ class TXCommitteeScraper(Scraper, LXMLMixin):
 
     def scrape_chamber(self, chamber):
         committee_list_urls = {
-            'lower': 'http://www.capitol.state.tx.us/Committees/'
+            'lower': 'https://capitol.texas.gov/Committees/'
                      'CommitteesMbrs.aspx?Chamber=H',
-            'upper': 'http://www.capitol.state.tx.us/Committees/'
+            'upper': 'https://capitol.texas.gov/Committees/'
                      'CommitteesMbrs.aspx?Chamber=S'
         }
 

--- a/openstates/tx/events.py
+++ b/openstates/tx/events.py
@@ -118,7 +118,7 @@ class TXEventScraper(Scraper, LXMLMixin):
                 'lower': 'H',
                 'other': 'J'}[chamber]
 
-        url = "http://www.capitol.state.tx.us/Committees/Committees.aspx" + \
+        url = "https://capitol.texas.gov/Committees/Committees.aspx" + \
               "?Chamber=" + chid
 
         page = self.lxmlize(url)
@@ -126,7 +126,7 @@ class TXEventScraper(Scraper, LXMLMixin):
         for ref in refs:
             yield from self.scrape_page(session, chamber, ref.attrib['href'])
 
-        url = "http://www.capitol.state.tx.us/Committees/MeetingsUpcoming.aspx" + \
+        url = "http://capitol.texas.gov/Committees/MeetingsUpcoming.aspx" + \
               "?Chamber=" + chid
 
         yield from self.scrape_upcoming_page(session, chamber, url)

--- a/openstates/tx/people.py
+++ b/openstates/tx/people.py
@@ -60,7 +60,7 @@ class TXPersonScraper(Scraper, LXMLMixin):
         # use only full-session slug for this
         session = self.latest_session()[:2]
 
-        url = ('http://www.lrl.state.tx.us/legeLeaders/members/membersearch.'
+        url = ('https://lrl.texas.gov/legeLeaders/members/membersearch.'
                'cfm?leg={}&chamber={}').format(session, chamber_map[chamber])
         page = self.lxmlize(url)
 
@@ -91,8 +91,8 @@ class TXPersonScraper(Scraper, LXMLMixin):
 
     def scrape_chamber(self, chamber):
         rosters = {
-            'lower': 'https://www.house.state.tx.us/members/',
-            'upper': 'http://www.senate.texas.gov/directory.php'
+            'lower': 'https://house.texas.gov/members/',
+            'upper': 'https://senate.texas.gov/directory.php'
         }
 
         roster_url = rosters[chamber]
@@ -108,7 +108,7 @@ class TXPersonScraper(Scraper, LXMLMixin):
         """
         Retrieves a list of members of the upper legislative chamber.
         """
-        # TODO: photo_urls http://www.senate.texas.gov/members.php
+        # TODO: photo_urls https://senate.texas.gov/members.php
         #       also available on individual member screens
         # TODO: email addresses could be scraped from secondary sources
         #       https://github.com/openstates/openstates/issues/1292

--- a/openstates/tx/people.py
+++ b/openstates/tx/people.py
@@ -12,9 +12,6 @@ from .utils import extract_phone, extract_fax
 class TXPersonScraper(Scraper, LXMLMixin):
     jurisdiction = 'tx'
 
-    # bad SSL as of July 2018
-    verify = False
-
     def __init__(self, *args, **kwargs):
         super(TXPersonScraper, self).__init__(*args, **kwargs)
 
@@ -96,7 +93,7 @@ class TXPersonScraper(Scraper, LXMLMixin):
         }
 
         roster_url = rosters[chamber]
-        response = self.get(roster_url, verify=False)
+        response = self.get(roster_url)
         # auto detect encoding
         response.encoding = response.apparent_encoding
         roster_page = lxml.html.fromstring(response.text)

--- a/openstates/tx/votes.py
+++ b/openstates/tx/votes.py
@@ -147,8 +147,8 @@ class BaseVote(object):
 
 
 # Note: Vote count patterns are inconsistent across journals and may follow the pattern
-# "145 Yeas, 0 Nays" (http://www.journals.house.state.tx.us/HJRNL/85R/HTML/85RDAY02FINAL.HTM) or
-# "Yeas 20, Nays 10" (http://www.journals.senate.state.tx.us/SJRNL/85R/HTML/85RSJ02-08-F.HTM)
+# "145 Yeas, 0 Nays" (https://journals.house.texas.gov/HJRNL/85R/HTML/85RDAY02FINAL.HTM) or
+# "Yeas 20, Nays 10" (https://journals.senate.texas.gov/SJRNL/85R/HTML/85RSJ02-08-F.HTM)
 class MaybeVote(BaseVote):
     yeas_pattern = re.compile(r'yeas[\s\xa0]+(\d+)|(\d+)[\s\xa0]+yeas', re.IGNORECASE)
     nays_pattern = re.compile(r'nays[\s\xa0]+(\d+)|(\d+)[\s\xa0]+nays', re.IGNORECASE)
@@ -334,7 +334,7 @@ class TXVoteScraper(Scraper):
         day_num = 1
         while journal_day <= today:
             if 'lower' in chambers:
-                journal_root = "http://www.journals.house.state.tx.us/HJRNL/%s/HTML/" % session
+                journal_root = "https://journals.house.texas.gov/HJRNL/%s/HTML/" % session
                 journal_url = journal_root + session + "DAY" + str(day_num).zfill(2) + "FINAL.HTM"
                 try:
                     self.get(journal_url)
@@ -344,7 +344,7 @@ class TXVoteScraper(Scraper):
                     yield from self.scrape_journal(journal_url, 'lower', session)
 
             if 'upper' in chambers:
-                journal_root = "http://www.journals.senate.state.tx.us/SJRNL/%s/HTML/" % session
+                journal_root = "https://journals.senate.texas.gov/SJRNL/%s/HTML/" % session
                 journal_url = journal_root + "%sSJ%s-%s-F.HTM" % (
                     session, str(journal_day.month).zfill(2), str(journal_day.day).zfill(2))
                 try:

--- a/scripts/newsblogs/urls/tx.txt
+++ b/scripts/newsblogs/urls/tx.txt
@@ -11,9 +11,9 @@ http://www.texastribune.org/feeds/main/
 http://blog.mysanantonio.com/politics/feed/
 http://www.star-telegram.com/legislature/index.atom
 http://www.txdemocrats.org/feed/
-http://www.house.state.tx.us/rss/rss.php
+http://house.texas.gov/rss/rss.php
 http://www.txhousedems.com/feed/
-http://governor.state.tx.us/rss/
+http://gov.texas.gov/rss/
 
 http://www.therepublic.com/feed/cat/2620
 http://www.pewstates.org/feeds/all.rss?states=328049


### PR DESCRIPTION
Texas has a new domain! Good, because SSL certs were a bit off on the old domain!

The old domains for the most part serve redirects to the new domains, except for some of the House member URLs whose SSL certs on old domain are too messed up for the redirect to work.