### PR TITLE
Pr add parties

### DIFF
--- a/dbinit.sh
+++ b/dbinit.sh
@@ -11,8 +11,12 @@ Progressive/Democratic
 Democratic/Progressive
 Democratic-Farmer-Labor
 Nonpartisan
+Partido Nuevo Progresista
+Partido Popular Democrático
+Partido Independentista Puertorriqueño
 "
 
+IFS=$(echo -en "\n\b")
 for party in ${parties}; do
   /opt/openstates/venv-pupa/bin/pupa party --action add "${party}"
 done

--- a/openstates/pr/__init__.py
+++ b/openstates/pr/__init__.py
@@ -61,7 +61,7 @@ class PuertoRico(Jurisdiction):
             upper.add_post(label=d, role=upper_title,
                            division_id='{}/sldu:{}'.format(self.division_id, i + 1))
         upper.add_post(label='At-Large', role=upper_title,
-                       division_id='{}/sldu'.format(self.division_id))
+                       division_id='{}/sldu:at-large'.format(self.division_id))
 
         # lower house is 40 seats, + 11 at large
         for n in range(1, 41):
@@ -69,7 +69,7 @@ class PuertoRico(Jurisdiction):
                 label=str(n), role=lower_title,
                 division_id='{}/sldl:{}'.format(self.division_id, n))
         lower.add_post(label='At-Large', role=lower_title,
-                       division_id='{}/sldl'.format(self.division_id))
+                       division_id='{}/sldl:at-large'.format(self.division_id))
 
         yield Organization(name='Office of the Governor', classification='executive')
         yield legislature


### PR DESCRIPTION
It looks like the at-large divisions we added for PR in #2507 don't exist in https://github.com/opencivicdata/ocd-division-ids. This patch replaces them with divisions that exist in our database. I also added some PR parties to `dbinit.sh` so that I can run the import locally.

@showerst @csnardi 