### PR TITLE
PR: Update fix for PS0623 year error

### DIFF
--- a/openstates/pr/bills.py
+++ b/openstates/pr/bills.py
@@ -141,8 +141,8 @@ class PRBillScraper(Scraper):
                 action_actor = chamber
 
         # manual fix for data error on 2017-2020 P S0623
-        if date == '8/1/1826':
-            date = '8/1/2018'
+        if date == datetime.datetime(1826, 8, 1):
+            date = date.replace(year=2018)
 
         bill.add_action(description=action.replace('.', ''),
                         date=date.strftime('%Y-%m-%d'),


### PR DESCRIPTION
Fixes #2518. By the time the date is in `parse_action`, it is in datetime form, so we need to make sure that we compare and modify it in datetime form.