### PR TITLE
Use /bin/bash instead of /bin/sh for dbinit

### DIFF
--- a/dbinit.sh
+++ b/dbinit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 /opt/openstates/venv-pupa/bin/pupa dbinit --country us
 


### PR DESCRIPTION
`sh` seems to split up some strings, so "Partido Independentista Puertorriqueño" wouldn't be added to the database as one party, it would be added as several different fragments. Switching to `bash` seems to fix this.