### PR TITLE
IN: Fix people and committee scrapers

### DIFF
--- a/billy_metadata/in.py
+++ b/billy_metadata/in.py
@@ -20,8 +20,8 @@ metadata = dict(
          'end_year': 2014, 'sessions': ['2013', '2014']},
         {'name': '2015-2016', 'start_year': 2015,
          'end_year': 2016, 'sessions': ['2015', '2016']},
-        {'name': '2017-2017', 'start_year': 2017,
-         'end_year': 2018, 'sessions': ['2017', '2018']},
+        {'name': '2017-2018', 'start_year': 2017,
+         'end_year': 2018, 'sessions': ['2017', '2018', '2018ss1']},
     ],
     session_details={
         '2009': {'display_name': '2009 Regular Session',

--- a/openstates/in/committees.py
+++ b/openstates/in/committees.py
@@ -51,8 +51,7 @@ class INCommitteeScraper(Scraper):
         return sc_dict
 
     def scrape(self):
-        session_name = self.latest_session()
-        session = session_name[0:5]
+        session = self.latest_session()
 
         subcomms = self.get_subcommittee_info(session)
 

--- a/openstates/in/people.py
+++ b/openstates/in/people.py
@@ -18,11 +18,10 @@ class INPersonScraper(Scraper):
 
     def scrape_chamber(self, chamber):
         client = ApiClient(self)
-        session_name = self.latest_session()
-        session = session_name[0:5]
+        session = self.latest_session()
         base_url = "http://iga.in.gov/legislative"
         api_base_url = "https://api.iga.in.gov"
-        chamber_name = "Senate" if chamber == "upper" else "House"
+        chamber_name = "senate" if chamber == "upper" else "house"
         r = client.get("chamber_legislators", session=session, chamber=chamber_name)
         all_pages = client.unpaginate(r)
         for leg in all_pages:

--- a/openstates/in/utils.py
+++ b/openstates/in/utils.py
@@ -5,14 +5,14 @@ def get_with_increasing_timeout(scraper, link, fail=False, kwargs={}):
     # if fail is true, we want to throw an error if we can't
     # access the page we need
     # if it's false, throw a warning and keep going
-    timeout_length = 2
+    timeout_length = 8
     html = None
     while timeout_length < 65 and html is None:
         try:
             html = scraper.get(link, timeout=timeout_length, **kwargs)
         except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
             old_length = timeout_length
-            timeout_length **= 2    # this squares the result. awesome.
+            timeout_length *= 2
             scraper.logger.debug("Timed out after {now} seconds, "
                                  "increasing to {next} and trying again".format(
                                      now=old_length, next=timeout_length)


### PR DESCRIPTION
This includes many fixes. First, don't limit the session name to 5 characters as this cuts off the end of `2018ss1`. Secondly, `senate` and `house` apparently need to be completely lowercase for the API URLs. Thirdly, adjust the read timeout to start at 8 seconds, as 2 seconds seems to be too low for many pages.

Finally, add `2018ss1` as an acceptable session for the 2017-2018 term, and fix a typo in the legislative term to be `2017-2018` instead of `2017-2017`. (Hopefully that typo fix won't break anything? Not sure if anything relies on that staying the same.)

Fixes #2228.