### PR TITLE
IA: Build history url.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-python: 3.5
+python: 3.6
 install: pip install flake8
 script: flake8 openstates
 notifications:

--- a/openstates/ia/bills.py
+++ b/openstates/ia/bills.py
@@ -78,11 +78,10 @@ class IABillScraper(Scraper):
         sidebar = lxml.html.fromstring(self.get(url).text)
         sidebar.make_links_absolute("https://www.legis.iowa.gov")
 
-        try:
-            hist_url = sidebar.xpath('//a[contains(., "Bill History")]')[0].attrib['href']
-        except IndexError:
-            # where is it?
-            return
+        hist_url = (
+            f'https://www.legis.iowa.gov/legislation/billTracking/'
+            f'billHistory?billName={bill_id}&ga={session_id}'
+        )
 
         page = lxml.html.fromstring(self.get(hist_url).text)
         page.make_links_absolute("https://www.legis.iowa.gov")


### PR DESCRIPTION
The bill history link seems to use js now and doesn't set the href
attribute; build the url from the bill and session ids instead.