### PR TITLE
GA: Add 2018 special session.

### DIFF
--- a/openstates/ga/__init__.py
+++ b/openstates/ga/__init__.py
@@ -43,7 +43,13 @@ class Georgia(Jurisdiction):
             "name": "2017-2018 Regular Session",
             'start_date': '2017-01-09',
             'end_date': '2017-03-31'
-        }
+        },
+        {
+            "_scraped_name": "2018 Special Session",
+            "identifier": "2018_ss",
+            "name": "2018 Special Session",
+            'start_date': '2018-11-13',
+        },
     ]
     ignored_scraped_sessions = [
         "2009-2010 Regular Session",

--- a/openstates/ga/util.py
+++ b/openstates/ga/util.py
@@ -51,6 +51,7 @@ def backoff(function, *args, **kwargs):
 
 
 SESSION_SITE_IDS = {
+    '2018_ss': 26,
     '2017_18': 25,
     '2015_16': 24,
     '2013_14': 23,


### PR DESCRIPTION
This doesn't actually work so far--looks like the GA API doesn't know about the new session yet. I'll check on this in a few days once the special starts.