### PR TITLE
KY: Add 2018 Dec Special Session

### DIFF
--- a/billy_metadata/ky.py
+++ b/billy_metadata/ky.py
@@ -42,6 +42,7 @@ metadata = {
             'sessions': [
                 '2017RS',
                 '2018RS',
+                '2018SS',
             ]
         },
     ],
@@ -120,6 +121,11 @@ metadata = {
             'start_date': datetime.date(2018, 1, 2),
             'display_name': '2018 Regular Session',
             '_scraped_name': '2018 Regular Session',
+        },
+        '2018SS': {
+            'type': 'primary',
+            'display_name': '2018 Special Session',
+            '_scraped_name': '2018 Special Session',
         },
     },
     'feature_flags': ['subjects', 'events', 'influenceexplorer'],

--- a/openstates/ky/__init__.py
+++ b/openstates/ky/__init__.py
@@ -118,10 +118,10 @@ class Kentucky(Jurisdiction):
         {
             "_scraped_name": "2018 Special Session",
             "classification": "special",
-            "end_date": "2018-04-13",
+            "end_date": "2018-12-18",
             "identifier": "2018SS",
             "name": "2018 Special Session",
-            "start_date": "2018-01-02"
+            "start_date": "2018-12-19"
         },
     ]
     ignored_scraped_sessions = []

--- a/openstates/ky/__init__.py
+++ b/openstates/ky/__init__.py
@@ -108,6 +108,21 @@ class Kentucky(Jurisdiction):
             "name": "2018 Regular Session",
             "start_date": "2018-01-02"
         },
+        {
+            "_scraped_name": "2019 Regular Session",
+            "classification": "primary",
+            "identifier": "2019RS",
+            "name": "2019 Regular Session",
+            "start_date": "2019-01-08"
+        },
+        {
+            "_scraped_name": "2018 Special Session",
+            "classification": "special",
+            "end_date": "2018-04-13",
+            "identifier": "2018SS",
+            "name": "2018 Special Session",
+            "start_date": "2018-01-02"
+        },
     ]
     ignored_scraped_sessions = []
 


### PR DESCRIPTION
I've also added 2019, but not by default. The prefiles can be scraped by:

```
pupa update ky bills --scrape session='2019RS' prefile=True
```