### PR TITLE
CA: Resolve sqlalchemy error on CAVoteDetail relationships

### DIFF
--- a/openstates/ca/models.py
+++ b/openstates/ca/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import (Column, Integer, String, ForeignKey,
                         DateTime, Numeric, UnicodeText)
 from sqlalchemy.sql import and_
-from sqlalchemy.orm import backref, relation
+from sqlalchemy.orm import backref, relation, foreign
 from sqlalchemy.ext.declarative import declarative_base
 
 from lxml import etree
@@ -225,8 +225,7 @@ class CAVoteSummary(Base):
 class CAVoteDetail(Base):
     __tablename__ = "bill_detail_vote_tbl"
 
-    bill_id = Column(String(20), ForeignKey(CABill.bill_id),
-                     ForeignKey(CAVoteSummary.bill_id), primary_key=True)
+    bill_id = Column(String(20), ForeignKey(CABill.bill_id), primary_key=True)
     location_code = Column(String(6), ForeignKey(CAVoteSummary.location_code),
                            primary_key=True)
     legislator_name = Column(String(50), primary_key=True)
@@ -240,10 +239,12 @@ class CAVoteDetail(Base):
     trans_uid = Column(String(30), primary_key=True)
     trans_update = Column(DateTime, primary_key=True)
 
-    bill = relation(CABill, backref=backref('detail_votes'))
+    bill = relation(CABill,
+                    primaryjoin="CABill.bill_id == foreign(CAVoteDetail.bill_id)",
+                    backref=backref('detail_votes'))
     summary = relation(
         CAVoteSummary,
-        primaryjoin=and_(CAVoteSummary.bill_id == bill_id,
+        primaryjoin=and_(CAVoteSummary.bill_id == foreign(bill_id),
                          CAVoteSummary.location_code == location_code,
                          CAVoteSummary.vote_date_time == vote_date_time,
                          CAVoteSummary.vote_date_seq == vote_date_seq,


### PR DESCRIPTION
In investigating a way to resolve #2672 I ran into the following error:

```
/opt/openstates/venv-pupa/lib/python3.6/site-packages/sqlalchemy/orm/relationships.py:2745: SAWarning: relationship 'CAVoteDetail.summary' will copy column bill_summary_vote_tbl.bill_id to column bill_detail_vote_tbl.bill_id, which conflicts with relationship(s): 'CAVoteDetail.bill' (copies bill_tbl.bill_id to bill_detail_vote_tbl.bill_id). Consider applying viewonly=True to read-only relationships, or provide a primaryjoin condition marking writable columns with the foreign() annotation.
```
when running `docker-compose run --rm scrape ca bills`

I don't know for sure if that's why CA is not running in your system, but once I made this change, I was able to successful run that command and see output that seemed to show the scraper running successfully (`INFO pupa: save bill SB1 in 20192020 as bill_4fd28ecc-0f9c-11e9-8f15-0242ac140005.json` etc). I am very new to this codebase but attempted to follow guidelines on the above error from https://docs.sqlalchemy.org/en/latest/orm/join_conditions.html

That said, I was not able to fully check this, as the `import bills...` step for me is popping this error `pupa.exceptions.UnresolvedIdError: cannot resolve pseudo id to Organization: ~{"classification": "lower"}` (which is maybe related to the fact that it seems like none of the CA juridstictions/organizations are showing up in the postgres DB, not sure why).