### PR TITLE
Updated docs regarding oregon API auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,3 @@ A few states require credentials to access their APIs. If you want to run code f
 
   * Get credentials at: http://docs.api.iga.in.gov/introduction.html
   * Set in environment prior to running scrape: ``INDIANA_API_KEY``
-
-* OR
-
-  * Get credentials at: https://www.oregonlegislature.gov/citizen_engagement/Pages/data.aspx
-  * Set in environment prior to running scrape: ``OLODATA_USERNAME`` and ``OLODATA_PASSWORD``

--- a/openstates/or/apiclient.py
+++ b/openstates/or/apiclient.py
@@ -34,8 +34,6 @@ class OregonLegislatorODataClient(object):
         if not scraper:
             scraper = requests.Session()
         self.scraper = scraper
-        self.username = os.environ['OLODATA_USERNAME']
-        self.password = os.environ['OLODATA_PASSWORD']
 
     def all_sessions(self):
         return self.get('sessions')
@@ -54,7 +52,6 @@ class OregonLegislatorODataClient(object):
         requests_args = requests_args or ()
         requests_kwargs = requests_kwargs or {}
         requests_kwargs.update(verify=True)
-        requests_kwargs.update(auth=(self.username, self.password))
         headers = requests_kwargs.get('headers', {})
         headers['Accept'] = "application/json"
         requests_kwargs['headers'] = headers

--- a/openstates/or/apiclient.py
+++ b/openstates/or/apiclient.py
@@ -1,5 +1,3 @@
-import os
-
 import requests
 
 


### PR DESCRIPTION
I emailed them for an API key but they said it does not require auth. Ran the scraper without it and it works great, but data has not been updated for 2019 yet.