### PR TITLE
OH regex fix

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -100,7 +100,7 @@ class OHBillScraper(Scraper):
                 bill_id = number_link.text_content().replace('No.', '')
                 bill_id = bill_id.replace('.', '').replace(' ', '')
                 # put one space back in between type and number
-                bill_id = re.sub(r'(\[a-zA-Z]+)(\d+)', r'\1 \2', bill_id)
+                bill_id = re.sub(r'([a-zA-Z]+)(\d+)', r'\1 \2', bill_id)
 
                 title = title.text_content().strip()
                 title = re.sub(r'^Title', '', title)

--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -100,7 +100,7 @@ class OHBillScraper(Scraper):
                 bill_id = number_link.text_content().replace('No.', '')
                 bill_id = bill_id.replace('.', '').replace(' ', '')
                 # put one space back in between type and number
-                bill_id = re.sub(r'(\w+)(\d+)', r'\1 \2', bill_id)
+                bill_id = re.sub(r'(\[a-zA-Z]+)(\d+)', r'\1 \2', bill_id)
 
                 title = title.text_content().strip()
                 title = re.sub(r'^Title', '', title)


### PR DESCRIPTION
My bill number cleanup regex in Ohio had an error that would've split double-digit numbered bills wrong. I noticed it in testing and caught it before any went live.