### PR TITLE
Add pupa_settings step to instructions for import to database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,11 @@ Then run database migrations and import jurisdictions::
 
     docker-compose run --rm dbinit
 
+You also need to enable the import of certain entities into the database. Change pupa_settings.py to::
+
+    ENABLE_PEOPLE_AND_ORGS = True
+    ENABLE_BILLS = True
+
 Now you can run the scrape service without the `--scrape` flag, and data will be imported into postgres. You can connect to the database and inspect data using `psql` (credentials are set in `docker-compose.yml`)::
 
     psql postgres://postgres:secret@localhost:5432/openstates


### PR DESCRIPTION
While trying to figure out how to run openstates code, I ran into a barrier: [data from state scraper not being imported into the database](https://github.com/openstates/openstates/pull/2745). I finally figured out that pupa_settings.py was essentially telling pupa not to import these things. I'm not sure why those are default settings in the repo - maybe they should be changed? - but at least I think they should be mentioned in the set of instructions that lead up to telling users that the scraper can save data to the database.