### PR TITLE
CT people scraper: handle malformed legislator URLs

### DIFF
--- a/openstates/ct/people.py
+++ b/openstates/ct/people.py
@@ -78,7 +78,13 @@ class CTPersonScraper(Scraper):
                          district=district,
                          party=party
                          )
-            leg.add_link(row['URL'])
+
+            legislator_url = row['URL'].replace('\\', '//').strip()
+            if legislator_url != '':
+                if not legislator_url.startswith('http'):
+                    legislator_url = 'http://'
+                leg.add_link(legislator_url)
+
             leg.add_party(party=party)
 
             office_address = "%s\nRoom %s\nHartford, CT 06106" % (


### PR DESCRIPTION
A couple malformed legislator URLs from the source document are causing the scraper to crash.