### PR TITLE
FL: More flexible date xpath.

### DIFF
--- a/openstates/fl/bills.py
+++ b/openstates/fl/bills.py
@@ -433,7 +433,7 @@ class HouseBillPage(Page):
 class HouseComVote(Page):
 
     def handle_page(self):
-        (date, ) = self.doc.xpath('//span[@id="ctl00_ContentPlaceHolder1_lblDate"]/text()')
+        date, = self.doc.xpath('//span[contains(@id, "lblDate"]/text()')
         date = format_datetime(datetime.datetime.strptime(date, '%m/%d/%Y %I:%M:%S %p'),
                                'US/Eastern')
 


### PR DESCRIPTION
Fixes http://bobsled.openstates.org/run-FL-2019-02-03.html.