### PR TITLE
WI: Set unique vote id.

### DIFF
--- a/openstates/wi/bills.py
+++ b/openstates/wi/bills.py
@@ -309,6 +309,7 @@ class WIBillScraper(Scraper):
             classification=vtype,
             bill=bill,
         )
+        v.pupa_id = url.split('/')[-1]
         v.set_count('yes', yes)
         v.set_count('no', no)
 


### PR DESCRIPTION
Handle votes with common name and date, like
http://docs.legis.wisconsin.gov/2019/related/votes/assembly/av0004 and
http://docs.legis.wisconsin.gov/2019/related/votes/assembly/av0005.