### PR TITLE
OH: Fix empty listing page

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -272,8 +272,6 @@ class OHBillScraper(Scraper):
             yield page
 
     def get_bill_rows(self, session, start=1):
-        bill_types = ['HR', 'HB', 'SR', 'SB', ]
-
         # bill API endpoint times out so we're now getting this from the normal search
         bill_url = ('https://www.legislature.ohio.gov/legislation/search?pageSize=500&start={}&'
                     'sort=LegislationNumber&dir=asc&statusCode&generalAssemblies={}'

--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -272,9 +272,12 @@ class OHBillScraper(Scraper):
             yield page
 
     def get_bill_rows(self, session, start=1):
+        bill_types = ['HR', 'HB', 'SR', 'SB', ]
+
         # bill API endpoint times out so we're now getting this from the normal search
         bill_url = ('https://www.legislature.ohio.gov/legislation/search?pageSize=500&start={}&'
-                    'sort=LegislationNumber&dir=asc&statusCode&generalAssemblies={}'.format(
+                    'sort=LegislationNumber&dir=asc&statusCode&generalAssemblies={}'
+                    '&legislationTypes=HR,HB,SR,SB,HCR,SCR,HJR,SJR'.format(
                         start, session)
                     )
         doc = self.get(bill_url)


### PR DESCRIPTION
By providing a legislation type filter, OH's website will return bills again.