### PR TITLE
[IL] Temporary fix for committee resolution

### DIFF
--- a/openstates/il/bills.py
+++ b/openstates/il/bills.py
@@ -332,7 +332,8 @@ class IlBillScraper(Scraper):
                 (name, source), = [(a.text, a.get('href')) for a in
                                    action_elem.xpath('a')
                                    if 'committee' in a.get('href')]
-                source = canonicalize_url(source)
+                # hack 101st session back to 100th, to match openstates/people
+                source = canonicalize_url(source).replace('&GA=101', '&GA=100')
                 actor_id = {'sources__url': source,
                             'classification': 'committee'}
                 committee_actors[source] = name
@@ -423,7 +424,8 @@ class IlBillScraper(Scraper):
                                in committee_actors.items()
                                if committee.startswith(first_word) and
                                chamber in url]
-                    actor = {'sources__url': source,
+                    # hack 101st session back to 100th, to match openstates/people
+                    actor = {'sources__url': source.replace('&GA=101', '&GA=100'),
                              'classification': 'committee'}
                 except ValueError:
                     self.warning("Can't resolve voting body for %s" %

--- a/openstates/ky/people.py
+++ b/openstates/ky/people.py
@@ -1,5 +1,4 @@
 import lxml.html
-from functools import reduce
 
 from pupa.scrape import Person, Scraper
 


### PR DESCRIPTION
This hacks the source url for committees, used in pseudo-id resolution, to set the session back from 101 to 100, to match the urls in the openstates/people committees.  This is intended to provide time to consider support for committees when not under the gun.

Issue: https://github.com/openstates/openstates/issues/2821 . 