### PR TITLE
Add major-version pinning to the Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 # common
-xlrd
-lxml>=2.2
-pytz>=2010l
-feedparser>=4.1
+xlrd>=1.2,<2
+lxml>=4.3,<5
+pytz>=2018
+feedparser>=5.2,<6
 spatula
 
+# development
+ipdb>=0.11
+
 # California
-SQLAlchemy
-mysqlclient
+SQLAlchemy>=1.3,<2
+mysqlclient>=1.4,<2
 
-# dev
-ipdb
+# Connecticut
+chardet>=3,<4
 
-#CT
-chardet
-
-# GA
-suds-py3
+# Georgia
+suds-py3>=1.3,<2


### PR DESCRIPTION
As I was dealing with a namespace issue with Cali's MySQL, I noticed that we don't protect against major-version bumps in our `requirements.txt`, which could contribute to those sorts of issues.

If this is intended behavior, then absolutely close this PR without merging, though; I could imagine a world where we always want the newest version of a Python library, and any breaking change will just be obvious to us (via a break in the production Bobsled logs), so prevention of a major-version bump is undesirable.