### PR TITLE
CA: Upgrade MySQL container from version 5 to 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
     - postgres
   mysql:
-    image: mysql:5.7
+    image: mysql:8
     command: mysqld --max_allowed_packet=512M
     ports:
     - "3306:3306"


### PR DESCRIPTION
Running the CA download and import using MySQL 8 instead of 5 is working smoothly. I'm not very familiar with the MySQL community, though; is using 5.7 still standard/best-practice?