### PR TITLE
Switch Docker Compose to MariaDB container, to mimic Alpine server used in production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
     depends_on:
     - postgres
   mysql:
-    image: mysql:8
-    command: mysqld --max_allowed_packet=512M
+    image: mariadb:10.3
+    command: mysqld_safe --max_allowed_packet=512M
     ports:
     - "3306:3306"
     environment:


### PR DESCRIPTION
Ugh, actually @showerst, the environment we should've been reproducing in Docker Compose is MariaDB. Alpine apparently switched from MySQL to MariaDB in their 3.2 release, and our Dockerfile uses MariaDB packages when installing (and then running in production).