### PR TITLE
MI: Fix broken version urls

### DIFF
--- a/openstates/mi/bills.py
+++ b/openstates/mi/bills.py
@@ -236,7 +236,7 @@ class MIBillScraper(Scraper):
                 name = name[0]
             else:
                 name = row.text_content().strip()
-            url = BASE_URL + a[0].get('href').replace('../', '/')
+            url = a[0].get('href')
             return name, url
 
     def parse_roll_call(self, url, rc_num):


### PR DESCRIPTION
Due to a site change we were registering MI versions with the absolute URL twice.