### PR TITLE
Restore dateutil dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ lxml>=4.3,<5
 pytz>=2018
 feedparser>=5.2,<6
 spatula
+python-dateutil
 
 # development
 ipdb>=0.11


### PR DESCRIPTION
Not sure what happened here, but apparently `python-dateutil` isn't in the image anymore. Maybe some upstream dependency changed its dependencies. Anyway, best to list in the requirements explicitly.