### PR TITLE
AZ: Skip bill actions without report date.

### DIFF
--- a/openstates/az/bills.py
+++ b/openstates/az/bills.py
@@ -205,17 +205,20 @@ class AZBillScraper(Scraper):
             else:
                 raise ValueError(
                     'Unexpected committee type: {}'.format(status['Committee']['TypeName']))
-            action_date = datetime.datetime.strptime(
-                status['ReportDate'], '%Y-%m-%dT%H:%M:%S').strftime('%Y-%m-%d')
-            bill.add_action(
-                description=status['Action'],
-                chamber={
-                    'S': 'upper',
-                    'H': 'lower',
-                }[status['Committee']['LegislativeBody']],
-                date=action_date,
-                classification=categories,
-            )
+            if status['ReportDate']:
+                action_date = datetime.datetime.strptime(
+                    status['ReportDate'], '%Y-%m-%dT%H:%M:%S').strftime('%Y-%m-%d')
+                bill.add_action(
+                    description=status['Action'],
+                    chamber={
+                        'S': 'upper',
+                        'H': 'lower',
+                    }[status['Committee']['LegislativeBody']],
+                    date=action_date,
+                    classification=categories,
+                )
+            else:
+                self.info("Action without report date: {}".format(status['Action']))
         else:
             # most of the unclassified ones are hearings
             # https://www.azleg.gov/faq/abbreviations/


### PR DESCRIPTION
Fixes #2917. Not sure if there's something better to do with actions that don't have report dates, but this at least makes the scraper stop failing.