### PR TITLE
KY: Included bolded actions from list

### DIFF
--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -102,7 +102,7 @@ class KYBillScraper(Scraper, LXMLMixin):
             )
             action_date = self._TZ.localize(action_date)
 
-            action_texts = row.xpath('td[1]/ul/li/text()')
+            action_texts = row.xpath('td[1]/ul/li/text() | td[1]/ul/li/strong/text()')
 
             for action_text in action_texts:
                 action_text = action_text.strip()


### PR DESCRIPTION
We were missing the bolded actions on the bill page action listing due to a narrow xpath. 