### PR TITLE
KS: Deal with new rate limit error, and add one action type

### DIFF
--- a/openstates/ks/bills.py
+++ b/openstates/ks/bills.py
@@ -189,6 +189,11 @@ class KSBillScraper(Scraper):
             self.warning("{} fetching vote {}, skipping".format(err, link))
             return
 
+        if 'Varnish cache server' in text:
+            self.warning("Scrape rate is too high, try re-scraping with "
+                         "The --rpm set to a lower number")
+            return
+
         if 'Page Not Found' in text or 'Page Unavailable' in text:
             self.warning("missing vote, skipping")
             return
@@ -199,7 +204,6 @@ class KSBillScraper(Scraper):
         vote_chamber = chamber_date_line_words[0]
         vote_date = datetime.datetime.strptime(chamber_date_line_words[-1], '%m/%d/%Y')
         vote_status = " ".join(chamber_date_line_words[2:-2])
-
         opinions = member_doc.xpath("//div[@id='main_content']/h3[position() > 1]/text()")
         if len(opinions) > 0:
             vote_status = vote_status if vote_status.strip() else motion[0]

--- a/openstates/ks/ksapi.py
+++ b/openstates/ks/ksapi.py
@@ -188,4 +188,5 @@ action_codes = {
     'mot_susp_206': None,
     'cur_con_101': None,  # concur. failed
     'cur_om_141': 'referral-committee',
+    'misc_he_200': None,
 }


### PR DESCRIPTION
Resolves #2921 this is another rate-limiting issue. This patch will get the scraper finishing by skipping some votes, we may need to drop the RPM as well here.