### PR TITLE
MI: Stop adding district numbers as sponsors

### DIFF
--- a/openstates/mi/bills.py
+++ b/openstates/mi/bills.py
@@ -87,6 +87,10 @@ class MIBillScraper(Scraper):
         sponsors = doc.xpath('//span[@id="frg_billstatus_SponsorList"]/a')
         for sponsor in sponsors:
             name = sponsor.text.replace(u'\xa0', ' ')
+            # sometimes district gets added as a link
+            if name.isnumeric():
+                continue
+
             if len(sponsors) > 1:
                 classification = (
                     'primary'


### PR DESCRIPTION
Due to a change in MI's html, we were picking up district links and adding them as bill sponsors, like "58".