### PR TITLE
Use LABEL instead of deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM        alpine:3.8
-MAINTAINER  James Turk <james@openstates.org>
+FROM  alpine:3.8
+LABEL maintainer="James Turk <james@openstates.org>"
 
 ENV PYTHONIOENCODING 'utf-8'
 ENV LANG 'en_US.UTF-8'


### PR DESCRIPTION
`MAINTAINER` instruction is deprecated [according to Docker docs](https://docs.docker.com/engine/reference/builder/#maintainer), so updated `Dockerfile` using suggestion in docs.

Tested rebuilding the image locally via `docker build -t openstates/test-build:1.0 .`:

```
REPOSITORY                                           TAG                 IMAGE ID            CREATED              SIZE
openstates/test-build                                1.0                 eb981864cd8f        About a minute ago   830MB
```