### PR TITLE
Ignore vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ site/openstates
 *.jar
 +*.sublime*
 venv
+.vscode/
 
 # Binary data files and dumps, from Open States and state websites
 openstates.sqlite3


### PR DESCRIPTION
Noticed `.vscode` directory added to root of repo when installing some extensions. Updated `.gitignore` so local settings not committed