### PR TITLE
Add space to scraped 2019 al session.

### DIFF
--- a/openstates/al/__init__.py
+++ b/openstates/al/__init__.py
@@ -106,7 +106,7 @@ class Alabama(Jurisdiction):
             "start_date": "2019-03-08"
         },
         {
-            "_scraped_name": "Regular Session 2019",
+            "_scraped_name": " Regular Session 2019",
             "classification": "primary",
             "end_date": "2019-06-17",
             "identifier": "2019rs",


### PR DESCRIPTION
Resolves #2954

Thanks to @jessemortenson for flagging; the state's list had a leading space typo.

Note that we'd usually strip those in the get_session_list function, but in this case we need the exact string to submit a form on the website later to get a session cookie.