### PR TITLE
CA: Fix overly broad action classifier

### DIFF
--- a/openstates/ca/actions.py
+++ b/openstates/ca/actions.py
@@ -36,7 +36,7 @@ _categorizer_rules = (
     Rule(r'refused to concur in Assembly amendments', 'amendment-failure'),
 
     Rule(r'Failed passage in committee', 'committee-failure'),
-    Rule(r'(?i)From committee', 'committee-passage'),
+    Rule(r'(?i)From committee: ((?!Without further action))', 'committee-passage'),
     Rule(r'(?i)From committee: Do pass', 'committee-passage-favorable'),
     Rule(r'From committee with author\'s amendments', 'committee-passage'),
 


### PR DESCRIPTION
State: CA

In https://leginfo.legislature.ca.gov/faces/billHistoryClient.xhtml?bill_id=201920200AB1586 and other bills, we were mis-classifying "From committee: Without further action pursuant to Joint Rule 62(a)." as committee passage.

Change the regex to exclude matches for that.