### PR TITLE
Patches: WV 2020

### DIFF
--- a/openstates/wv/__init__.py
+++ b/openstates/wv/__init__.py
@@ -115,6 +115,7 @@ class WestVirginia(Jurisdiction):
         },
     ]
     ignored_scraped_sessions = [
+        "2020",
         "2010",
         "2009",
         "2008",


### PR DESCRIPTION
Add 2020 to list of ignored scrape sessions for WV (at least while it has no data)