### PR TITLE
AL: Fix bill version is an amendment with empty name/filename

### DIFF
--- a/openstates/al/bills.py
+++ b/openstates/al/bills.py
@@ -357,8 +357,9 @@ class ALBillScraper(Scraper):
 
                 (action_chamber, ) = action.xpath('td[2]/font/text()')
 
-                if action.xpath('td[3]/font/u/text()'):
-                    (amendment, ) = action.xpath('td[3]/font/u/text()')
+                possible_amendment = action.xpath('td[3]/font/u/text()')
+                if len(possible_amendment) > 0 and not possible_amendment[0].strip() == '':
+                    (amendment, ) = possible_amendment
                 else:
                     amendment = None
 


### PR DESCRIPTION
I found a handful of bills in AL where there is a space (nbsp) in a table cell that the scraper code was checking to look for amendments (which get turned into bill versions). This is an error or typo on the AL website side, which results in broken bill versions, like [HB 70](https://openstates.org/graphql?operationName=null&query=%7B%0A%20%20bill(id%3A%20%22ocd-bill%2Fa4e55a92-f6d2-4b78-bcc7-d52a6b260786%22)%20%7B%0A%0A%20%20%20%20%20%20%20%20id%2C%0A%20%20%20%20%20%20%20%20title%2C%0A%20%20%20%20identifier%0A%20%20%20%20legislativeSession%20%7B%0A%20%20%20%20%20%20identifier%0A%20%20%20%20%7D%0A%20%20%20%20sources%20%7B%0A%20%20%20%20%20%20url%0A%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20versions%20%7B%0A%20%20%20%20%20%20%20%20%20%20note%0A%20%20%20%20%20%20%20%20%20%20date%2C%0A%20%20%20%20%20%20%20%20%20%20links%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20mediaType%0A%20%20%20%20%20%20%20%20%20%20%20%20url%0A%20%20%20%20%20%20%20%20%20%20%20%20text%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%7D%0A%7D):

```
{
          "note": "Amd/Sub  ",
          "date": "",
          "links": [
            {
              "mediaType": "application/pdf",
              "url": "http://alisondb.legislature.state.al.us/ALISON/SearchableInstruments/2019rs/PrintFiles/ .pdf",
              "text": ""
            }
          ]
        }
```

This AL bill URLs are useless but here it is (2019 regular session): http://alisondb.legislature.state.al.us/Alison/SESSBillStatusResult.ASPX?BILL=HB70&WIN_TYPE=BillResult