### PR TITLE
IL: fix duplicate 'lv' versions causing "Duplicate Entry" errors

### DIFF
--- a/openstates/il/bills.py
+++ b/openstates/il/bills.py
@@ -389,8 +389,8 @@ class IlBillScraper(Scraper):
             if 'print=true' not in url:
                 if name in VERSION_TYPES:
                     if pdf_only:
-                        # we actually need to visit the version's page, and get the PDF link from there
-                        # otherwise we'll be grabbing the aforementioned "latest version"/"LV" alias/duplicate
+                        # eed to visit the version's page, and get PDF link from there
+                        # otherwise get a faulty "latest version"/"LV" alias/duplicate
                         version_page_html = self.get(url).text
                         version_page_doc = lxml.html.fromstring(version_page_html)
                         version_page_doc.make_links_absolute(url)


### PR DESCRIPTION
Fixes #2949 (I think)

The IL scraper goes to the "Full Text" link on the bill page to find bill versions ([HB 2698 example](http://ilga.gov/legislation/fulltext.asp?DocName=&SessionId=108&GA=101&DocTypeId=HB&DocNum=2698&GAID=15&LegID=118910&SpecSess=&Session=)). For bills that do *not* have HTML bill text available, the scraper attempts to locate PDF urls for each bill version. However, there is a link on the "Full Text" page labeled "PDF" that does not go to a unique bill version. Instead, it goes to a PDF file that appears to be an alias/duplicate of the most recent bill version (LV = Last Version? Latest Version?). For HB 2968, it is [10100HB2698lv.pdf](http://ilga.gov/legislation/101/HB/PDF/10100HB2698lv.pdf). Since the alias is actually a duplicate of an actual bill version, as the bill accrues additional versions the old scraper code will detect a new version name, but with the same URL. This causes ["Duplicate Entry" errors](http://bobsled.openstates.org/run-IL-2019-06-08.html).

I think the bug is only triggered if a) a bill has *only PDF* bill version documents available, and b) it has more than one bill version. 