### PR TITLE
NY: Make text url load full billtext

### DIFF
--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -317,7 +317,7 @@ class NYBillScraper(Scraper):
 
             html_version = version + ' HTML'
             html_url = 'http://assembly.state.ny.us/leg/?sh=printbill&bn='\
-                '{}&term={}'.format(bill_id, self.term_start_year)
+                '{}&term={}&Text=Y'.format(bill_id, self.term_start_year)
             bill.add_version_link(
                 html_version,
                 html_url,


### PR DESCRIPTION
By default NY HTML urls weren't pulling the bill's text, you had to click a button. This changes the URLs to include the billtext.