### PR TITLE
NJ: convert session year to int in _init_mdb

### DIFF
--- a/openstates/nj/utils.py
+++ b/openstates/nj/utils.py
@@ -26,7 +26,7 @@ def chamber_name(chamber):
 class MDBMixin(object):
 
     def _init_mdb(self, year):
-        if year < 2018:
+        if int(year) < 2018:
             self.mdbfile = 'DB%s.mdb' % year
             url = 'ftp://www.njleg.state.nj.us/ag/%sdata/DB%s.zip' % (year, year)
             fname, resp = self.urlretrieve(url)


### PR DESCRIPTION
Fixes: #3046

In the NJ People scraper, just convert the year string (parsed from the session name) to an int when comparing in `_init_mdb`.