### PR TITLE
UT: Simplify session logic and add 2020 session

### DIFF
--- a/openstates/ut/__init__.py
+++ b/openstates/ut/__init__.py
@@ -190,6 +190,14 @@ class Utah(Jurisdiction):
             "name": "2019 2nd Special Session",
             "start_date": "2019-12-11",
         },
+        {
+            "_scraped_name": "2020 General Session",
+            "classification": "primary",
+            "identifier": "2020",
+            "name": "2020 General Session",
+            "start_date": "2020-01-27",
+            "end_date": "2020-03-12",
+        },
     ]
     ignored_scraped_sessions = [
         "2011 Veto Override Session",

--- a/openstates/ut/bills.py
+++ b/openstates/ut/bills.py
@@ -34,30 +34,14 @@ class UTBillScraper(Scraper, LXMLMixin):
         #             url='https://le.utah.gov/~2019/bills/static/HB0087.html'
         #         )
 
-        # Identify the index page for the given session
-        sessions = self.lxmlize("http://le.utah.gov/Documents/bills.htm")
+        if "S" in session:
+            session_slug = session
+        else:
+            session_slug = "{}GS".format(session)
 
-        session_search_text = session
-        if "s" not in session.lower() and "h" not in session.lower():
-            session_search_text += "GS"
-
-        sessions = sessions.xpath(
-            '//li/a[contains(@href, "{}")]'.format(session_search_text)
+        session_url = "https://le.utah.gov/DynaBill/BillList?session={}".format(
+            session_slug
         )
-
-        session_url = ""
-        S = [
-            i
-            for i, _ in enumerate(self.jurisdiction.legislative_sessions)
-            if _["identifier"] == session
-        ][0]
-        for elem in sessions:
-            if (
-                re.sub(r"\s+", " ", elem.xpath("text()")[0])
-                == self.jurisdiction.legislative_sessions[S]["_scraped_name"]
-            ):
-                session_url = elem.xpath("@href")[0]
-        assert session_url
 
         # For some sessions the link doesn't go straight to the bill list
         doc = self.lxmlize(session_url)


### PR DESCRIPTION
UT sometimes posts session data without adding an actual link to their sessions index page, but the session IDs always follow a predictable pattern.

In this case they've been prefiling for 2020 for a while, but without linking it up correctly.