### PR TITLE
ma: senate resolution handling

### DIFF
--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -91,7 +91,11 @@ class MABillScraper(Scraper):
         chamber_filter = self.chamber_filters[self.chamber_map[chamber]]
         search_url = (
             "https://malegislature.gov/Bills/Search?"
-            "SearchTerms=&Page={}&Refinements%5Blawsgeneralcourt%5D={}"
+            "SearchTerms="
+            "&Page={}"
+            "&SortManagedProperty=lawsbillnumber"
+            "&Direction=asc"
+            "&Refinements%5Blawsgeneralcourt%5D={}"
             "&Refinements%5Blawsbranchname%5D={}".format(
                 pageNumber, session_filter, chamber_filter
             )

--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -163,7 +163,13 @@ class MABillScraper(Scraper):
             self.warning("Couldn't find title for {}; skipping".format(bill_id))
             return False
 
-        bill_id = re.sub(r"[^S|H|D|\d]", "", bill_id)
+        bill_types = ['H', 'HD', 'S', 'SD', 'SRes']
+        if re.sub('[0-9]', '', bill_id) not in bill_types:
+            self.warning("Unsupported bill type for {}; skipping".format(bill_id))
+            return False
+
+        if 'SRes' in bill_id:
+            bill_id = bill_id.replace('SRes', 'SR')
 
         bill = Bill(
             bill_id,


### PR DESCRIPTION
addresses https://github.com/openstates/openstates/issues/3058

changes:
- specify a list of expected bill types, and check against that. (this was verified against all bills that are coming back from most recent session. only failures were https://malegislature.gov/Bills/191/S2405,AppendixA and other appendix links for S2405. these links are broken anyway, and were already failing.. however https://malegislature.gov/Bills/191/S2405A works, do we want to make an issue for that?)
- non sequitur: sort by bill number when scraping chambers for better usability 

confirmed that this change fixes the import issue for MA/191/SR1