### PR TITLE
ma: strip whitespace on persons and committees

### DIFF
--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -226,6 +226,7 @@ class MABillScraper(Scraper):
             if not any(
                 sponsor["name"] == cosponsor_name for sponsor in bill.sponsorships
             ):
+                cosponsor_name = cosponsor_name.strip()
                 bill.add_sponsorship(
                     cosponsor_name,
                     classification="cosponsor",
@@ -355,6 +356,7 @@ class MABillScraper(Scraper):
                 classification=attrs["classification"],
             )
             for com in attrs.get("committees", []):
+                com = com.strip()
                 action.add_related_entity(com, entity_type="organization")
 
     def get_house_pdf(self, vurl):


### PR DESCRIPTION
there was significant trailing whitespace on people names and committees, that would need to be stripped later, and also was preventing people name matching. not sure if this is the best way to handle this.