### PR TITLE
HI: dont skip first bill version in table

### DIFF
--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -162,9 +162,7 @@ class HIBillScraper(Scraper):
 
     def parse_bill_versions_table(self, bill, versions):
         versions = versions.xpath("./*")
-        if len(versions) > 1:
-            versions = versions[1:]
-
+        
         if versions == []:
             raise Exception("Missing bill versions.")
 


### PR DESCRIPTION
HI was skipping the first bill in the versions table for every bill with > 1 version, perhaps because of a header row that used to be in the markup. This resolves that.