### PR TITLE
HI: Collect additional documents and fix events

### DIFF
--- a/openstates/hi/__init__.py
+++ b/openstates/hi/__init__.py
@@ -2,7 +2,7 @@ from pupa.scrape import Jurisdiction, Organization
 from openstates.utils.lxmlize import url_xpath
 from .people import HIPersonScraper
 
-# from .events import HIEventScraper
+from .events import HIEventScraper
 from .bills import HIBillScraper
 
 # from .committees import HICommitteeScraper
@@ -20,7 +20,7 @@ class Hawaii(Jurisdiction):
         "people": HIPersonScraper,
         "bills": HIBillScraper,
         # 'committees': HICommitteeScraper,
-        # 'events': HIEventScraper
+        'events': HIEventScraper
     }
     legislative_sessions = [
         {

--- a/openstates/hi/__init__.py
+++ b/openstates/hi/__init__.py
@@ -20,7 +20,7 @@ class Hawaii(Jurisdiction):
         "people": HIPersonScraper,
         "bills": HIBillScraper,
         # 'committees': HICommitteeScraper,
-        'events': HIEventScraper
+        "events": HIEventScraper,
     }
     legislative_sessions = [
         {

--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -210,7 +210,6 @@ class HIBillScraper(Scraper):
 
             last_item = name
             media_type = self.classify_media(filename)
-            print(filename, name, media_type)
 
             bill.add_document_link(name, filename, media_type=media_type)
 
@@ -229,7 +228,6 @@ class HIBillScraper(Scraper):
 
             last_item = name
             media_type = self.classify_media(filename)
-            print(filename, name, media_type)
 
             bill.add_document_link(name, filename, media_type=media_type)
 

--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -240,7 +240,7 @@ class HIBillScraper(Scraper):
 
         qs = dict(urlparse.parse_qsl(urlparse.urlparse(url).query))
         bill_id = "{}{}".format(qs["billtype"], qs["billnumber"])
-        versions = bill_page.xpath("//table[contains(@id, 'GridViewTestimony')]")[0]
+        versions = bill_page.xpath("//table[contains(@id, 'GridViewVersions')]")[0]
 
         metainf_table = bill_page.xpath(
             '//div[contains(@id, "itemPlaceholder")]//table[1]'

--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -162,7 +162,7 @@ class HIBillScraper(Scraper):
 
     def parse_bill_versions_table(self, bill, versions):
         versions = versions.xpath("./*")
-        
+
         if versions == []:
             raise Exception("Missing bill versions.")
 
@@ -171,7 +171,7 @@ class HIBillScraper(Scraper):
             if "No other versions" in tds[0].text_content():
                 return
 
-            if version.xpath('./a'):
+            if version.xpath("./a"):
                 http_href = tds[0].xpath("./a")
                 name = http_href[0].text_content().strip()
                 pdf_href = tds[1].xpath("./a")
@@ -184,30 +184,29 @@ class HIBillScraper(Scraper):
 
     def classify_media(self, url):
         media_type = None
-        if 'pdf' in url.lower():
-            media_type="application/pdf"
-        elif '.htm' in url.lower():
-            media_type="text/html"
-        elif '.docx' in url.lower():
-            media_type='application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-        elif '.doc' in url.lower():
-            media_type='application/msword'
+        if "pdf" in url.lower():
+            media_type = "application/pdf"
+        elif ".htm" in url.lower():
+            media_type = "text/html"
+        elif ".docx" in url.lower():
+            media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        elif ".doc" in url.lower():
+            media_type = "application/msword"
         return media_type
 
     def parse_testimony(self, bill, page):
         links = page.xpath("//table[contains(@id, 'GridViewTestimony')]/tr/td/a")
 
         # sometimes they have a second link w/ an icon for the pdf, sometimes now
-        last_item = ''
+        last_item = ""
 
         for link in links:
-            filename = link.attrib['href']
+            filename = link.attrib["href"]
             name = link.text_content().strip()
-            if name == '' and last_item != '':
+            if name == "" and last_item != "":
                 name = last_item
             else:
-                name = 'Testimony {}'.format(name)
-
+                name = "Testimony {}".format(name)
 
             last_item = name
             media_type = self.classify_media(filename)
@@ -218,15 +217,15 @@ class HIBillScraper(Scraper):
     def parse_cmte_reports(self, bill, page):
         links = page.xpath("//table[contains(@id, 'GridViewCommRpt')]/tr/td/a")
         # sometimes they have a second link w/ an icon for the pdf, sometimes now
-        last_item = ''
+        last_item = ""
 
         for link in links:
-            filename = link.attrib['href']
+            filename = link.attrib["href"]
             name = link.text_content().strip()
-            if name == '' and last_item != '':
+            if name == "" and last_item != "":
                 name = last_item
             else:
-                name = 'Committee Report {}'.format(name)
+                name = "Committee Report {}".format(name)
 
             last_item = name
             media_type = self.classify_media(filename)
@@ -290,7 +289,7 @@ class HIBillScraper(Scraper):
                 )
         for sponsor in meta["Introducer(s)"]:
             b.add_sponsorship(sponsor, "primary", "person", True)
-        
+
         self.parse_bill_versions_table(b, versions)
         self.parse_testimony(b, bill_page)
         self.parse_cmte_reports(b, bill_page)

--- a/openstates/hi/events.py
+++ b/openstates/hi/events.py
@@ -40,7 +40,7 @@ class HIEventScraper(Scraper, LXMLMixin):
     def scrape(self):
         get_short_codes(self)
         page = self.lxmlize(URL)
-        table = page.xpath("//table[@id='ContentPlaceHolderCol1_GridView1']")[0]
+        table = page.xpath("//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']")[0]
 
         for event in table.xpath(".//tr")[1:]:
             tds = event.xpath("./td")
@@ -82,6 +82,6 @@ class HIEventScraper(Scraper, LXMLMixin):
             event.add_source(URL)
             event.add_document(notice_name, notice_href, media_type="text/html")
             for bill in self.get_related_bills(notice_href):
-                a = event.add_agenda_item(description=bill["descr"])
+                a = event.add_agenda_item(description=bill["descr"].strip())
                 a.add_bill(bill["bill_id"], note=bill["type"])
             yield event

--- a/openstates/hi/events.py
+++ b/openstates/hi/events.py
@@ -8,6 +8,7 @@ import pytz
 
 URL = "http://www.capitol.hawaii.gov/upcominghearings.aspx"
 
+TIMEZONE = pytz.timezone("Pacific/Honolulu")
 
 class HIEventScraper(Scraper, LXMLMixin):
     def get_related_bills(self, href):
@@ -55,7 +56,7 @@ class HIEventScraper(Scraper, LXMLMixin):
             notice_href = notice.attrib["href"]
             notice_name = notice.text
             when = dt.datetime.strptime(when, "%m/%d/%Y %I:%M %p")
-            when = pytz.utc.localize(when)
+            when = TIMEZONE.localize(when)
             event = Event(
                 name=descr,
                 start_date=when,

--- a/openstates/hi/utils.py
+++ b/openstates/hi/utils.py
@@ -1,13 +1,12 @@
 import lxml
 
-HI_URL_BASE = "http://capitol.hawaii.gov"
+HI_URL_BASE = "https://capitol.hawaii.gov"
 SHORT_CODES = "%s/committees/committees.aspx?chamber=all" % (HI_URL_BASE)
-
 
 def get_short_codes(scraper):
     list_html = scraper.get(SHORT_CODES).text
     list_page = lxml.html.fromstring(list_html)
-    rows = list_page.xpath("//table[@id='ContentPlaceHolderCol1_GridView1']/tr")
+    rows = list_page.xpath("//table[@id='ctl00_ContentPlaceHolderCol1_GridView1']/tr")
     scraper.short_ids = {"CONF": {"chamber": "joint", "name": "Conference Committee"}}
 
     for row in rows:
@@ -18,10 +17,10 @@ def get_short_codes(scraper):
         clong = clong.xpath("./a")[0]
         short_id = short.text_content().strip()
         ctty_name = clong.text_content().strip()
-        chamber = "joint"
         if "house" in chamber.lower():
             chamber = "lower"
         elif "senate" in chamber.lower():
             chamber = "upper"
-
+        else:
+            chamber = "joint"
         scraper.short_ids[short_id] = {"chamber": chamber, "name": ctty_name}

--- a/openstates/hi/utils.py
+++ b/openstates/hi/utils.py
@@ -3,6 +3,7 @@ import lxml
 HI_URL_BASE = "https://capitol.hawaii.gov"
 SHORT_CODES = "%s/committees/committees.aspx?chamber=all" % (HI_URL_BASE)
 
+
 def get_short_codes(scraper):
     list_html = scraper.get(SHORT_CODES).text
     list_page = lxml.html.fromstring(list_html)


### PR DESCRIPTION
State: HI

1. Allow the versions table to have a header (it appears on some pages and not on others)
1. Collect document links to witness testimony and committee reports
1. Fix and re-enable the events scraper
