### PR TITLE
VA: Add action for successful votes, committee subs

### DIFF
--- a/openstates/va/bills.py
+++ b/openstates/va/bills.py
@@ -44,7 +44,7 @@ ACTION_CLASSIFIERS = (
     ("Read third time", "reading-3"),
     ("Senators: ", SKIP),
     ("Delegates: ", SKIP),
-    ("Committee substitute printed", SKIP),
+    ("Committee substitute printed", "substitution"),
     ("Bill text as passed", SKIP),
     ("Acts of Assembly", SKIP),
 )
@@ -279,7 +279,7 @@ class BillDetailPage(Page, Spatula):
                         cached_vote.add_source(vote_url[0])
                     else:
                         cached_vote.add_source(self.url)
-                    continue
+                    # continue
                 elif cached_vote is not None:
                     if vote_action.startswith(u"VOTE:"):
                         counts = {


### PR DESCRIPTION
@jamesturk currently the VA scraper is skipping adding actions for votes, which makes our pages not match the source. I restored that (and the committee sub action, which a customer asked us about, so i guess is relevant).

Let me know if you'd rather not have those as actions since they're also getting broken out as votes. I think both are useful, since often people just skim the actions section.