### PR TITLE
IN: Switch title to bill description

### DIFF
--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -284,10 +284,10 @@ class INBillScraper(Scraper):
                 self.logger.warning("Bill could not be accessed. Skipping.")
                 continue
 
-            title = bill_json["title"]
+            title = bill_json["description"]
             if title == "NoneNone":
                 title = None
-            # sometimes title is blank
+            # sometimes description is blank
             # if that's the case, we can check to see if
             # the latest version has a short description
             if not title:


### PR DESCRIPTION
Currently, the API's bill title is used as its title to store in the database. However, this title is not very helpful. For instance, this year's HB 1001 title is:

> A BILL FOR AN ACT concerning education.

Versus the description:

> School accountability.

This changes the stored title to be the bill description and not the API title.

Comments are welcome as to which is the preferred title (I presume as the more descriptive item the description is), and whether or not this will create any problems for already existing bills.