### PR TITLE
NY: Scrape amendments to bills as versions on the base bill

### DIFF
--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -38,7 +38,7 @@ class NYBillScraper(Scraper):
         return (bill_chamber, bill_type)
 
     def _parse_bill_details(self, bill):
-        bill_id = bill["printNo"]
+        bill_id = bill["basePrintNo"]
         assert bill_id
 
         # Parse the bill ID into its prefix and number.
@@ -358,7 +358,7 @@ class NYBillScraper(Scraper):
 
             pdf_version = version + " PDF"
             pdf_url = "http://legislation.nysenate.gov/pdf/bills/{}/{}".format(
-                self.term_start_year, bill_id
+                self.term_start_year, version
             )
             bill.add_version_link(
                 pdf_version,


### PR DESCRIPTION
Status quo behavior is that each amendment to a bill gets scraped and recorded as a separate bill. Each bill has two versions, the HTML and the PDF version. Issue raised as #3017 

This change uses `basePrintNo` to identify the bill uniquely, and then `printNo` to identify each version of the bill. Results in a versions array that looks like:

```
"versions": [
    {
      "note": "S6513 HTML",
      "links": [
        {
          "url": "http://assembly.state.ny.us/leg/?sh=printbill&bn=S6513&term=2019&Text=Y",
          "media_type": "text/html",
          "text": ""
        }
      ],
      "date": ""
    },
    {
      "note": "S6513 PDF",
      "links": [
        {
          "url": "http://legislation.nysenate.gov/pdf/bills/2019/S6513",
          "media_type": "application/pdf",
          "text": ""
        }
      ],
      "date": ""
    },
    {
      "note": "S6513A PDF",
      "links": [
        {
          "url": "http://legislation.nysenate.gov/pdf/bills/2019/S6513A",
          "media_type": "application/pdf",
          "text": ""
        }
      ],
      "date": ""
    }
  ]
```