### PR TITLE
AZ: Fixes to bill scraper

### DIFF
--- a/openstates/az/utils.py
+++ b/openstates/az/utils.py
@@ -53,8 +53,8 @@ bill_types = {
 
 # Return the actor for each action type, or 'chamber' for the bill's home chamber
 action_chamber_map = {
-    "House": "upper",
-    "Senate": "lower",
+    "House": "lower",
+    "Senate": "upper",
     "RequestforEnactment": "chamber",
     "IntroducedDate": "chamber",
     "PreFileDate": "chamber",


### PR DESCRIPTION
The AZ bill scraper currently marks first readings as occurring in the wrong chamber due to the upper and lower chamber being flipped in `action_chamber_map`. It misses second readings because their dates have milliseconds whereas those for first readings do not. These bugs are fixed in the scraper.

Additionally, the scraper contains old code sorting the bill actions, seemingly from a time when it was important that actions be sorted according to their dates. Since the website should do this itself now, and the code had the side effect of lower-casing action descriptions, remove the sorting code entirely.