### PR TITLE
IN: Add abstract if available

### DIFF
--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -450,6 +450,10 @@ class INBillScraper(Scraper):
             for subject in subjects:
                 bill.add_subject(subject)
 
+            # Abstract
+            if bill_json["latestVersion"]["digest"]:
+                bill.add_abstract(bill_json["latestVersion"]["digest"], note="Digest")
+
             # versions and votes
             for version in bill_json["versions"][::-1]:
                 try:


### PR DESCRIPTION
The Indiana bill API makes digests available, so add it as a bill abstract if available.