### PR TITLE
NY: fix different file types being saved as different versions

### DIFF
--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -347,21 +347,19 @@ class NYBillScraper(Scraper):
         for key, amendment in amendments.items():
             version = amendment["printNo"]
 
-            html_version = version + " HTML"
             html_url = (
                 "http://assembly.state.ny.us/leg/?sh=printbill&bn="
                 "{}&term={}&Text=Y".format(bill_id, self.term_start_year)
             )
             bill.add_version_link(
-                html_version, html_url, on_duplicate="ignore", media_type="text/html"
+                version, html_url, on_duplicate="ignore", media_type="text/html"
             )
 
-            pdf_version = version + " PDF"
             pdf_url = "http://legislation.nysenate.gov/pdf/bills/{}/{}".format(
                 self.term_start_year, version
             )
             bill.add_version_link(
-                pdf_version,
+                version,
                 pdf_url,
                 on_duplicate="ignore",
                 media_type="application/pdf",
@@ -424,6 +422,7 @@ class NYBillScraper(Scraper):
                     "ER": "excused",
                     "AB": "absent",
                     "NV": "not voting",
+                    "EL": "other"
                 }
 
                 for vote_pair in votes:


### PR DESCRIPTION
Also fix bug when encountered a previously unknown vote status EL. I could not find any reference material on the web that would explain what "EL" status is for a vote, so I left it as "other".

Improvement to previous code change based on my colleague's [comment](https://github.com/openstates/openstates/pull/3179#issuecomment-592190629) re: fix for #3017

New versions array looks like:

```
"versions": [
    {
      "note": "S4389",
      "links": [
        {
          "url": "http://assembly.state.ny.us/leg/?sh=printbill&bn=S4389&term=2019&Text=Y",
          "media_type": "text/html",
          "text": ""
        },
        {
          "url": "http://legislation.nysenate.gov/pdf/bills/2019/S4389",
          "media_type": "application/pdf",
          "text": ""
        }
      ],
      "date": ""
    },
    {
      "note": "S4389A",
      "links": [
        {
          "url": "http://legislation.nysenate.gov/pdf/bills/2019/S4389A",
          "media_type": "application/pdf",
          "text": ""
        }
      ],
      "date": ""
    },
    {
      "note": "S4389B",
      "links": [
        {
          "url": "http://legislation.nysenate.gov/pdf/bills/2019/S4389B",
          "media_type": "application/pdf",
          "text": ""
        }
      ],
      "date": ""
    }
  ]
```