### PR TITLE
IL: Adjust sponsor xpath for tags with multiple classes

### DIFF
--- a/openstates/il/bills.py
+++ b/openstates/il/bills.py
@@ -484,7 +484,7 @@ class IlBillScraper(Scraper):
 
         bill.add_source(url)
         # sponsors
-        sponsor_list = build_sponsor_list(doc.xpath('//a[@class="content"]'))
+        sponsor_list = build_sponsor_list(doc.xpath('//a[contains(@class, "content")]'))
         # don't add just yet; we can make them better using action data
 
         committee_actors = {}


### PR DESCRIPTION
The xpath searching for sponsors in Illinois bills assumes that links to sponsors will only have the class `content`. However, tags after the first sponsor also contain the class `notranslate`. Update the xpath to account for this so we catch each sponsor for a bill.