### PR TITLE
PA: Strip vote from member name in roll call votes

### DIFF
--- a/openstates/pa/bills.py
+++ b/openstates/pa/bills.py
@@ -355,7 +355,7 @@ class PABillScraper(Scraper):
         vote.set_count("other", other)
 
         for div in page.xpath('//*[contains(@class, "RollCalls-Vote")]'):
-            name = div.text_content().strip()
+            name = div.text.strip()
             name = re.sub(r"^[\s,]+", "", name)
             name = re.sub(r"[\s,]+$", "", name)
             class_attr = div.attrib["class"].lower()


### PR DESCRIPTION
In roll call votes, the bill scraper grabs all the text in the vote div as the member's name. However, the div also contains a Y/N/E/X in a child element to record what the member's vote was. By using only the text of the div itself, we will only capture the member's name and not their vote.