### PR TITLE
PA: Fix member name for vote

### DIFF
--- a/openstates/pa/bills.py
+++ b/openstates/pa/bills.py
@@ -355,7 +355,7 @@ class PABillScraper(Scraper):
         vote.set_count("other", other)
 
         for div in page.xpath('//*[contains(@class, "RollCalls-Vote")]'):
-            name = div.text.strip()
+            name = div[0].tail.strip()
             name = re.sub(r"^[\s,]+", "", name)
             name = re.sub(r"[\s,]+$", "", name)
             class_attr = div.attrib["class"].lower()


### PR DESCRIPTION
In #3193, I adjusted the way member's names were found for roll call votes. However, `.text` does not actually provide the member's name, since the text comes after the child element. Adjust the code to instead use text that comes after the first child element.