### PR TITLE
MI: Convert newlines in roll call votes to spaces

### DIFF
--- a/openstates/mi/bills.py
+++ b/openstates/mi/bills.py
@@ -281,7 +281,7 @@ class MIBillScraper(Scraper):
             return
 
         # split the file into lines using the <p> tags
-        pieces = [p.text_content().replace(u"\xa0", " ") for p in vote_doc.xpath("//p")]
+        pieces = [p.text_content().replace(u"\xa0", " ").replace("\r\n", " ") for p in vote_doc.xpath("//p")]
 
         # go until we find the roll call
         for i, p in enumerate(pieces):
@@ -305,9 +305,9 @@ class MIBillScraper(Scraper):
             elif p.startswith("In The Chair:"):
                 break
             elif vtype:
-                # split on spaces not preceeded by commas
-                for l in re.split(r"(?<!,)\s+", p):
-                    if l:
+                # split on multiple spaces not preceeded by commas
+                for l in re.split(r"(?<!,)\s{2,}", p):
+                    if l.strip():
                         results[vtype].append(l)
             else:
                 self.warning("piece without vtype set: %s", p)


### PR DESCRIPTION
The House and Senate journals occasionally have newlines in place of spaces, leading to the phrases "Not Voting" and "In The Chair" not being recognized. Replace these newline characters with spaces so the phrases are recognized correctly.

Also split lines with names on multiple spaces as Rep. O'Malley's name is sometimes recorded in the journal as "O Malley", causing his name to be split across two votes.