### PR TITLE
MO, NH, NJ, NM, SC, UT: Clean legislator names

### DIFF
--- a/openstates/mo/bills.py
+++ b/openstates/mo/bills.py
@@ -498,6 +498,7 @@ class MOBillScraper(Scraper, LXMLMixin):
         bill.add_source(url)
 
         bill_sponsor = clean_text(table_rows[0][1].text_content())
+        bill_sponsor = ' '.join(bill_sponsor.split(", ")[::-1])
         # try:
         #     bill_sponsor_link = table_rows[0][1][0].attrib['href']
         # except IndexError:

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -183,11 +183,11 @@ class NHBillScraper(Scraper):
             if len(line) < 2:
                 continue
 
-            line = line.split("|")
+            line = [l.strip() for l in line.split("|")]
             employee_num = line[0]
 
             # first, last, middle
-            if len(line) > 2:
+            if line[3]:
                 name = "%s %s %s" % (line[2], line[3], line[1])
             else:
                 name = "%s %s" % (line[2], line[1])

--- a/openstates/nj/bills.py
+++ b/openstates/nj/bills.py
@@ -303,6 +303,7 @@ class NJBillScraper(Scraper, MDBMixin):
                 continue
             bill = bill_dict[bill_id]
             name = rec["Sponsor"]
+            name = ' '.join(name.split(", ")[::-1])
             sponsor_type = rec["Type"]
             if sponsor_type == "P":
                 sponsor_type = "primary"

--- a/openstates/nm/bills.py
+++ b/openstates/nm/bills.py
@@ -92,7 +92,11 @@ class NMBillScraper(Scraper):
         # read in sponsor & subject mappings
         sponsor_map = {}
         for sponsor in self.access_to_csv("tblSponsors"):
-            sponsor_map[sponsor["SponsorCode"]] = sponsor["FullName"]
+            name = sponsor["FullName"].split(", ")
+            if len(name) == 3:
+                name.insert(0, ", " + name.pop(2))
+            name = ' '.join(name[::-1])
+            sponsor_map[sponsor["SponsorCode"]] = name
 
         # McSorley resigned so they removed him from the API
         # but he is still attached to some bills

--- a/openstates/sc/bills.py
+++ b/openstates/sc/bills.py
@@ -308,6 +308,10 @@ class SCBillScraper(Scraper):
                 names = re.split(r"\s{3,}", line)
                 for name in names:
                     if name:
+                        name = name.split(", ")
+                        if len(name) == 3:
+                            name.insert(0, ", " + name.pop(2))
+                        name = ' '.join(name[::-1])
                         if not option:
                             current_vfunc(name.strip())
                         else:

--- a/openstates/ut/bills.py
+++ b/openstates/ut/bills.py
@@ -118,6 +118,7 @@ class UTBillScraper(Scraper, LXMLMixin):
                 continue
             assert title == "Bill Sponsor:"
             name = name.replace("Sen. ", "").replace("Rep. ", "")
+            name = ' '.join(name.split(", ")[::-1])
             bill.add_sponsorship(
                 name, classification="primary", entity_type="person", primary=True
             )
@@ -129,6 +130,7 @@ class UTBillScraper(Scraper, LXMLMixin):
         elif len(floor_info) == 2:
             assert floor_info[0] == "Floor Sponsor:"
             floor_sponsor = floor_info[1].replace("Sen. ", "").replace("Rep. ", "")
+            floor_sponsor = ' '.join(floor_sponsor.split(", ")[::-1])
             bill.add_sponsorship(
                 floor_sponsor,
                 classification="cosponsor",


### PR DESCRIPTION
Scrapers in these states were often not able to match legislators since they were not formatted as expected. In every state except for NH, the names were formatted as last, first. This change flips the formatting for names in these states to be first, last. In NH, additional spaces were accidentally added to names, which this change prevents.