### PR TITLE
MA: Remove junk text from sponsor names, Fix titles

### DIFF
--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -264,6 +264,7 @@ class MABillScraper(Scraper):
             ):
                 cosponsor_name = (
                     cosponsor_name.replace("*", "")
+                    .replace("%", "")
                     .replace("This sponsor is an original petitioner.", "")
                     .strip()
                 )

--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -219,6 +219,7 @@ class MABillScraper(Scraper):
             sponsor = (
                 sponsor[0]
                 .replace("*", "")
+                .replace("%", "")
                 .replace("This sponsor is an original petitioner.", "")
                 .strip()
             )

--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -174,14 +174,16 @@ class MABillScraper(Scraper):
                 0
             ]
         except IndexError:
+            bill_title = None
             pass
 
-        try:
-            bill_title = page.xpath('//div[contains(@class,"followable")]/h1/text()')[0]
-            bill_title = bill_title.replace("Bill", "").strip()
-        except IndexError:
-            self.warning("Couldn't find title for {}; skipping".format(bill_id))
-            return False
+        if bill_title is None:
+            try:
+                bill_title = page.xpath('//div[contains(@class,"followable")]/h1/text()')[0]
+                bill_title = bill_title.replace("Bill", "").strip()
+            except IndexError:
+                self.warning("Couldn't find title for {}; skipping".format(bill_id))
+                return False
 
         bill_types = ["H", "HD", "S", "SD", "SRes"]
         if re.sub("[0-9]", "", bill_id) not in bill_types:

--- a/openstates/ma/bills.py
+++ b/openstates/ma/bills.py
@@ -177,10 +177,8 @@ class MABillScraper(Scraper):
             pass
 
         try:
-            bill_title = page.xpath('//div[contains(@class,"followable")]/h1/text()')[
-                0
-            ]
-            bill_title = bill_title.replace('Bill', '').strip()
+            bill_title = page.xpath('//div[contains(@class,"followable")]/h1/text()')[0]
+            bill_title = bill_title.replace("Bill", "").strip()
         except IndexError:
             self.warning("Couldn't find title for {}; skipping".format(bill_id))
             return False
@@ -218,7 +216,12 @@ class MABillScraper(Scraper):
             "following-sibling::dd/descendant-or-self::*/text()[normalize-space()]"
         )
         if sponsor:
-            sponsor = sponsor[0].strip()
+            sponsor = (
+                sponsor[0]
+                .replace("*", "")
+                .replace("This sponsor is an original petitioner.", "")
+                .strip()
+            )
             bill.add_sponsorship(
                 sponsor, classification="primary", primary=True, entity_type="person"
             )
@@ -258,7 +261,11 @@ class MABillScraper(Scraper):
             if not any(
                 sponsor["name"] == cosponsor_name for sponsor in bill.sponsorships
             ):
-                cosponsor_name = cosponsor_name.strip()
+                cosponsor_name = (
+                    cosponsor_name.replace("*", "")
+                    .replace("This sponsor is an original petitioner.", "")
+                    .strip()
+                )
                 bill.add_sponsorship(
                     cosponsor_name,
                     classification="cosponsor",


### PR DESCRIPTION
Due to a markup change in MA, the scraper is picking up a bunch of sponsor names ending in "(whitespace) This sponsor is an original petitioner. (whitespace) *". Strip that out.

Due to a recent attempt to fix titles w/ alternate markup, we were overwriting the title in many cases w/ the bill number. This restores the titles.