### PR TITLE
CA: Updates to action parser for joint rule 56

### DIFF
--- a/openstates/ca/actions.py
+++ b/openstates/ca/actions.py
@@ -29,13 +29,21 @@ _categorizer_rules = (
     Rule(r"amendments concurred in", "amendment-passage"),
     Rule(r"refused to concur in Assembly amendments", "amendment-failure"),
     Rule(r"Failed passage in committee", "committee-failure"),
-    Rule(r"(?i)From committee: ((?!Without further action))", "committee-passage"),
+    Rule(
+        r"From committee: Filed with the Chief Clerk pursuant to Joint Rule 56.",
+        "failure",
+    ),
+    Rule(
+        r"(?i)From committee: ((?!Without further action))((?!Filed with the Chief Clerk pursuant to Joint Rule 56))",
+        "committee-passage",
+    ),
     Rule(r"(?i)From committee: Do pass", "committee-passage-favorable"),
     Rule(r"From committee with author\'s amendments", "committee-passage"),
     # Resolutions
     Rule(r"Adopted", "passage"),
     Rule(r"Read", "reading-1"),
     Rule(r"^From committee: Be adopted", "committee-passage-favorable"),
+    Rule(r"^Died pursuant to", "failure"),
 )
 
 


### PR DESCRIPTION
The CA parser was marking bills that had died as 'passed committee' due to the actions starting with 'From Committee:' -- this fixes that.

Ex: http://leginfo.legislature.ca.gov/faces/billHistoryClient.xhtml?bill_id=201920200AB700

@schneidy I don't think this conflicts w/ your CA work but let me know if so.
