### PR TITLE
WV: voter name issue

### DIFF
--- a/openstates/wv/bills.py
+++ b/openstates/wv/bills.py
@@ -347,6 +347,9 @@ class WVBillScraper(Scraper):
 
             for key, values in votes.items():
                 for value in values:
+                    if "*" in value:
+                        value = value.replace("*", "")
+                        print(value)
                     vote.vote(key, value)
 
             yield vote

--- a/openstates/wv/bills.py
+++ b/openstates/wv/bills.py
@@ -347,9 +347,10 @@ class WVBillScraper(Scraper):
 
             for key, values in votes.items():
                 for value in values:
+                    if "Committee" in value:
+                        continue
                     if "*" in value:
                         value = value.replace("*", "")
-                        print(value)
                     vote.vote(key, value)
 
             yield vote


### PR DESCRIPTION
West Virginia no longer has * showing up before voter names.

Also removed any voter names that had the word "committee" in them.

Related to issue #3263 