### PR TITLE
NH: Sponsor names extra spaces have been removed.

### DIFF
--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -209,9 +209,12 @@ class NHBillScraper(Scraper):
             if session_yr == session and lsr in self.bills:
                 sp_type = "primary" if primary == "1" else "cosponsor"
                 try:
+                    # Removes extra spaces in names
+                    sponsor_name = self.legislators[employee]["name"].strip()
+                    sponsor_name = " ".join(sponsor_name.split())
                     self.bills[lsr].add_sponsorship(
                         classification=sp_type,
-                        name=self.legislators[employee]["name"],
+                        name=sponsor_name,
                         entity_type="person",
                         primary=True if sp_type == "primary" else False,
                     )


### PR DESCRIPTION
New Hampshire: Sponsor names extra spaces have been removed.

Related to issue #3261 