### PR TITLE
HI Vote and Sponsor Name Issues

### DIFF
--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -286,6 +286,10 @@ class HIBillScraper(Scraper):
                     relation_type="companion",
                 )
         for sponsor in meta["Introducer(s)"]:
+            if "(Introduced by request of another party)" in sponsor:
+                sponsor = sponsor.replace(
+                    " (Introduced by request of another party)", ""
+                )
             b.add_sponsorship(sponsor, "primary", "person", True)
 
         self.parse_bill_versions_table(b, versions)

--- a/openstates/hi/bills.py
+++ b/openstates/hi/bills.py
@@ -147,18 +147,29 @@ class HIBillScraper(Scraper):
                 vote.set_count("no", int(v["n_no"] or 0))
                 vote.set_count("not voting", int(v["n_excused"] or 0))
                 for voter in split_specific_votes(v["yes"]):
+                    voter = self.clean_voter_name(voter)
                     vote.yes(voter)
                 for voter in split_specific_votes(v["yes_resv"]):
+                    voter = self.clean_voter_name(voter)
                     vote.yes(voter)
                 for voter in split_specific_votes(v["no"]):
+                    voter = self.clean_voter_name(voter)
                     vote.no(voter)
                 for voter in split_specific_votes(v["excused"]):
+                    voter = self.clean_voter_name(voter)
                     vote.vote("not voting", voter)
 
                 yield vote
 
             elif re.search("reconsider", string, re.IGNORECASE):
                 reconsiderations.add(actor)
+
+    def clean_voter_name(self, name):
+        if name[-1] == ".":
+            name = name[:-2]
+        if name[0] == " ":
+            name = name[1:]
+        return name.strip()
 
     def parse_bill_versions_table(self, bill, versions):
         versions = versions.xpath("./*")


### PR DESCRIPTION
Hawaii:

Removed '(Introduced by request of another party)' from sponsor names.

Added a function to remove extra periods and spaces from voter names.

Should fix issue #3257 
